### PR TITLE
Remove dev.orcasound.net data

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -28,7 +28,6 @@ namespace OrcanodeMonitor.Core
         private static TimeZoneInfo _pacificTimeZone = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
         private static HttpClient _httpClient = new HttpClient();
         private static string _orcasoundProdSite = "live.orcasound.net";
-        private static string _orcasoundDevSite = "dev.orcasound.net";
         private static string _orcasoundFeedsUrlPath = "/api/json/feeds";
         private static string _dataplicityDevicesUrl = "https://apps.dataplicity.com/devices/";
         private static string _mezmoViewsUrl = "https://api.mezmo.com/v1/config/view";
@@ -886,7 +885,6 @@ namespace OrcanodeMonitor.Core
             try
             {
                 await UpdateOrcasoundSiteDataAsync(context, _orcasoundProdSite, foundList, unfoundList);
-                await UpdateOrcasoundSiteDataAsync(context, _orcasoundDevSite, foundList, unfoundList);
 
                 // Mark any remaining unfound nodes as absent.
                 foreach (var unfoundNode in unfoundList)

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -358,15 +358,15 @@ namespace OrcanodeMonitor.Models
                 {
                     return "Dev";
                 }
-                if (this.DataplicityName.ToLower().StartsWith("live"))
+                if (this.DataplicityName.StartsWith("live", StringComparison.OrdinalIgnoreCase))
                 {
                     return "Prod";
                 }
-                if (this.DataplicityName.ToLower().StartsWith("dev"))
+                if (this.DataplicityName.StartsWith("dev", StringComparison.OrdinalIgnoreCase))
                 {
                     return "Dev";
                 }
-                if (this.DataplicityName.ToLower().StartsWith("beta"))
+                if (this.DataplicityName.StartsWith("beta", StringComparison.OrdinalIgnoreCase))
                 {
                     return "Beta";
                 }

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -350,23 +350,29 @@ namespace OrcanodeMonitor.Models
             }
         }
 
-        private bool IsDev
+        public string Type
         {
             get
             {
                 if (this.S3Bucket.StartsWith("dev"))
                 {
-                    return true;
+                    return "Dev";
+                }
+                if (this.DataplicityName.ToLower().StartsWith("live"))
+                {
+                    return "Prod";
                 }
                 if (this.DataplicityName.ToLower().StartsWith("dev"))
                 {
-                    return true;
+                    return "Dev";
                 }
-                return false;
+                if (this.DataplicityName.ToLower().StartsWith("beta"))
+                {
+                    return "Beta";
+                }
+                return "Unknown";
             }
         }
-
-        public string Type => IsDev ? "Dev" : "Prod";
 
         public string OrcasoundOnlineStatusString {
             get

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -105,6 +105,18 @@
     <h4 style="text-align: left;">Legend</h4>
     <ul style="text-align: left;">
         <li>
+            <b>Type Beta</b>: The node is in beta testing.
+        </li>
+        <li>
+            <b>Type Dev</b>: The node is a developer node.
+        </li>
+        <li>
+            <b>Type Prod</b>: The node is a production node.
+        </li>
+        <li>
+            <b>Type Unknown</b>: The node is type is unknown.
+        </li>
+        <li>
             <b>Dataplicity Absent</b>: Dataplicity does not know about the node.
         </li>
         <li>

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -105,13 +105,13 @@ namespace OrcanodeMonitor.Pages
         public async Task OnGetAsync()
         {
             var nodes = await _databaseContext.Orcanodes.ToListAsync();
-            _nodes = nodes.Where(n => n.DataplicityConnectionStatus != OrcanodeOnlineStatus.Absent ||
-                                          n.OrcasoundStatus != OrcanodeOnlineStatus.Absent ||
-                                          (n.S3StreamStatus != OrcanodeOnlineStatus.Absent &&
-                                          n.S3StreamStatus != OrcanodeOnlineStatus.Unauthorized))
-                              .OrderByDescending(n => n.Type)
-                              .ThenBy(n => n.DisplayName)
-                              .ToList();
+            _nodes = nodes.Where(n => ((n.DataplicityConnectionStatus != OrcanodeOnlineStatus.Absent) ||
+                                       (n.OrcasoundStatus != OrcanodeOnlineStatus.Absent) ||
+                                       (n.S3StreamStatus != OrcanodeOnlineStatus.Absent &&
+                                        n.S3StreamStatus != OrcanodeOnlineStatus.Unauthorized)) &&
+                                      (n.OrcasoundHost != "dev.orcasound.net"))
+                          .OrderBy(n => n.DisplayName)
+                          .ToList();
         }
     }
 }


### PR DESCRIPTION
Only use live.orcasound.net since dev.orcasound.net should not have a separate database.

Also display "Beta" and "Unknown" as types and update the legend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced display of node statuses with a new legend defining node types: Beta, Dev, Prod, and Unknown.
	- Improved `Type` property in the `Orcanode` class for clearer categorization of node status.

- **Bug Fixes**
	- Updated filtering logic for node instances to exclude development site nodes.

- **Documentation**
	- Added explanations for node types in the legend to improve user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->