### PR TITLE
Add uptime column to the dashboard

### DIFF
--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -374,6 +374,8 @@ namespace OrcanodeMonitor.Models
             }
         }
 
+        public static string OnlineString => "up";
+
         public string OrcasoundOnlineStatusString {
             get
             {
@@ -381,7 +383,7 @@ namespace OrcanodeMonitor.Models
                 OrcanodeOnlineStatus status = S3StreamStatus;
 
                 // Convert to a display string.
-                return (status == OrcanodeOnlineStatus.Online) ? "up" : S3StreamStatus.ToString().ToUpper();
+                return (status == OrcanodeOnlineStatus.Online) ? OnlineString : S3StreamStatus.ToString().ToUpper();
             }
         }
         #endregion derived

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -18,6 +18,7 @@
             <th>SD Card Util.</th>
             <th><a href="https://app.mezmo.com/313dbd82f3/logs/view" target="_blank">Mezmo</a></th>
             <th><a href="https://open.quiltdata.com/b/audio-orcasound-net/tree/" target="_blank">S3 Stream</a></th>
+            <th>Up%</th>
             <th><a href="https://live.orcasound.net/listen" target="_blank">Orcasound</a></th>
             <th><a href="https://aifororcas2.azurewebsites.net/hydrophones" target="_blank">OrcaHello</a></th>
         </tr>
@@ -70,6 +71,9 @@
                     </a>
                 </td>
             }
+            <td>
+                @Model.GetUptimePercentage(item)%
+            </td>
             @if (item.OrcasoundStatus == Models.OrcanodeOnlineStatus.Absent)
             {
                 <td style="background-color: @Model.NodeOrcasoundBackgroundColor(item); color: @Model.NodeOrcasoundTextColor(item)">

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -71,7 +71,7 @@
                     </a>
                 </td>
             }
-            <td>
+            <td style="background-color: @Model.NodeUptimePercentageBackgroundColor(item); color: @Model.NodeUptimePercentageTextColor(item)">
                 @Model.GetUptimePercentage(item)%
             </td>
             @if (item.OrcasoundStatus == Models.OrcanodeOnlineStatus.Absent)

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -137,6 +137,29 @@ namespace OrcanodeMonitor.Pages
             return (int)((100.0 * up) / _uptimeEvaluationPeriod + 0.5);
         }
 
+        public string NodeUptimePercentageBackgroundColor(Orcanode node)
+        {
+            int value = GetUptimePercentage(node);
+            if (value < 1)
+            {
+                return ColorTranslator.ToHtml(Color.Red);
+            }
+            else if (value > 99)
+            {
+                return ColorTranslator.ToHtml(Color.LightGreen);
+            }
+
+            return ColorTranslator.ToHtml(Color.Yellow);
+        }
+        public string NodeUptimePercentageTextColor(Orcanode node)
+        {
+            if (NodeUptimePercentageBackgroundColor(node) == ColorTranslator.ToHtml(Color.Red))
+            {
+                return ColorTranslator.ToHtml(Color.White);
+            }
+            return ColorTranslator.ToHtml(Color.FromArgb(0, 0, 238));
+        }
+
         public string NodeDataplicityUpgradeColor(Orcanode node)
         {
             OrcanodeUpgradeStatus status = node.DataplicityUpgradeStatus;

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -106,8 +106,14 @@ namespace OrcanodeMonitor.Pages
             DateTime start = DateTime.UtcNow - _uptimeEvaluationPeriod;
             string lastValue = string.Empty;
 
+            // Get events sorted by date to ensure correct chronological processing
+            var nodeEvents = _events
+                   .Where(e => e.Orcanode == node)
+                   .OrderBy(e => e.DateTimeUtc)
+                   .ToList();
+
             // Compute uptime percentage by looking at OrcanodeEvents over the past week.
-            foreach (OrcanodeEvent e in _events.Where(e => (e.Orcanode == node)))
+            foreach (OrcanodeEvent e in nodeEvents)
             {
                 if (DateTime.UtcNow - e.DateTimeUtc >= _uptimeEvaluationPeriod) {
                     // More than a week old.

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -121,7 +121,7 @@ namespace OrcanodeMonitor.Pages
                     continue;
                 }
                 DateTime current = e.DateTimeUtc;
-                if (lastValue == "up")
+                if (lastValue == Orcanode.OnlineString)
                 {
                     up += (current - start);
                 }
@@ -132,7 +132,7 @@ namespace OrcanodeMonitor.Pages
                 start = current;
                 lastValue = e.Value;
             }
-            if (lastValue == "up")
+            if (lastValue == Orcanode.OnlineString)
             {
                 up += DateTime.UtcNow - start;
             } else


### PR DESCRIPTION
Add uptime column to the dashboard where percentage is computed from "hydrophone stream" events over the past week

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Up%" column in the node status table, displaying the uptime percentage for each node.
	- Enhanced uptime calculations based on recent events for improved monitoring of Orcanodes.

- **Bug Fixes**
	- Improved data fetching for Orcanode events, ensuring accurate uptime reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->