### PR TITLE
Fix uptime computation on node events page

### DIFF
--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -422,7 +422,7 @@ namespace OrcanodeMonitor.Models
 
             // Get events sorted by date to ensure correct chronological processing.
             var nodeEvents = events
-                   .Where(e => e.OrcanodeId == orcanodeId)
+                   .Where(e => e.OrcanodeId == orcanodeId && e.Type == "hydrophone stream")
                    .OrderBy(e => e.DateTimeUtc)
                    .ToList();
 

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -394,12 +394,14 @@ namespace OrcanodeMonitor.Models
 
         /// <summary>
         /// Calculates the uptime percentage for a node based on its events since a specified date.
+        /// Only events of type "hydrophone stream" are considered when calculating uptime.
+        /// These events indicate the actual streaming status of the node's hydrophone.
         /// </summary>
         /// <param name="orcanodeId">The ID of the node to calculate uptime for</param>
         /// <param name="events">List of node events</param>
         /// <param name="since">The start date for uptime calculation</param>
         /// <returns>Uptime percentage as an integer between 0 and 100</returns>
-        /// <exception cref="ArgumentException">Thrown when orcanodeId is null or empty</exception>         
+        /// <exception cref="ArgumentException">Thrown when orcanodeId is null or empty</exception>
         public static int GetUptimePercentage(string orcanodeId, List<OrcanodeEvent> events, DateTime since)
         {
             if (string.IsNullOrEmpty(orcanodeId))


### PR DESCRIPTION
Fixes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced uptime calculation by filtering node events to include only "hydrophone stream" events, leading to potentially more accurate uptime percentages.
- **Documentation**
	- Updated method documentation to reflect the new filtering criteria for uptime calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->