### PR TITLE
Expose node name in events API for IFTTT

### DIFF
--- a/OrcanodeMonitor/Models/OrcanodeEvent.cs
+++ b/OrcanodeMonitor/Models/OrcanodeEvent.cs
@@ -28,6 +28,7 @@ namespace OrcanodeMonitor.Models
     {
         public OrcanodeIftttEventDTO(string id, string nodeName, string slug, string type, string value, DateTime timestamp, int severity)
         {
+            NodeName = nodeName;
             Slug = slug;
             Type = type;
             Value = value;
@@ -37,6 +38,8 @@ namespace OrcanodeMonitor.Models
         }
         [JsonPropertyName("slug")]
         public string Slug { get; private set; }
+        [JsonPropertyName("node_name")]
+        public string NodeName { get; private set; }
         [JsonPropertyName("type")]
         public string Type { get; private set; }
         [JsonPropertyName("value")]

--- a/OrcanodeMonitor/Models/OrcanodeEvent.cs
+++ b/OrcanodeMonitor/Models/OrcanodeEvent.cs
@@ -38,8 +38,13 @@ namespace OrcanodeMonitor.Models
         }
         [JsonPropertyName("slug")]
         public string Slug { get; private set; }
+
+        /// <summary>
+        /// The node name used in IFTTT event identification.
+        /// </summary>
         [JsonPropertyName("node_name")]
         public string NodeName { get; private set; }
+
         [JsonPropertyName("type")]
         public string Type { get; private set; }
         [JsonPropertyName("value")]


### PR DESCRIPTION
Addresses part of #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `NodeName`, to enhance event details in the Orcanode IFTTT integration.
	- Updated the event constructor to include `NodeName` for improved data handling.
	- Enhanced the `Description` formatting to utilize the new `NodeName` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->