### PR TITLE
Label times as being in Pacific time zone

### DIFF
--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -7,7 +7,7 @@
 <div class="text-center">
     <h1 class="display-4">Current State</h1>
     <p>
-        Status as of: @Model.LastChecked
+        Status as of: @Model.LastChecked Pacific
     </p>
     <table>
         <tr>
@@ -180,7 +180,7 @@
     <table>
         <thead>
             <tr>
-                <th>Timestamp</th>
+                <th>Timestamp (Pacific)</th>
                 <th>Event</th>
             </tr>
         </thead>

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml
@@ -57,7 +57,7 @@
     <table class="table">
         <thead>
             <tr>
-                <th>Timestamp</th>
+                <th>Timestamp (Pacific)</th>
                 <th>Event</th>
             </tr>
         </thead>


### PR DESCRIPTION
Fixes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated timestamp displays to specify "Pacific" timezone in both the status and events tables.
  
- **Bug Fixes**
	- Clarified timestamp headers to improve user understanding of displayed times. 

- **Documentation**
	- Enhanced clarity in the user interface regarding time zone specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->