### PR TITLE
Use separate  cosmosdb containers for production vs staging vs development

### DIFF
--- a/OrcanodeMonitor/Data/OrcanodeMonitorContext.cs
+++ b/OrcanodeMonitor/Data/OrcanodeMonitorContext.cs
@@ -20,41 +20,47 @@ namespace OrcanodeMonitor.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? string.Empty;
+            if (environment == "Production")
+            {
+                environment = string.Empty;
+            }
+
             modelBuilder.Entity<MonitorState>()
-               .ToContainer("MonitorState")
+               .ToContainer(environment + "MonitorState")
                .Property(item => item.ID)
                .HasConversion<string>();
 
             modelBuilder.Entity<MonitorState>()
-                .ToContainer("MonitorState")
+                .ToContainer(environment + "MonitorState")
                 .HasPartitionKey(item=>item.ID);
 
             modelBuilder.Entity<Orcanode>()
-                .ToContainer("Orcanode")
+                .ToContainer(environment + "Orcanode")
                 .Property(item => item.PartitionValue)
                 .HasConversion<string>();
 
             modelBuilder.Entity<Orcanode>()
-                .ToContainer("Orcanode")
+                .ToContainer(environment + "Orcanode")
                 .Property(item => item.ID);
 
             modelBuilder.Entity<Orcanode>()
-                .ToContainer("Orcanode")
+                .ToContainer(environment + "Orcanode")
                 .Property(item => item.AudioStreamStatus)
                 .HasDefaultValue(OrcanodeOnlineStatus.Absent);
 
             modelBuilder.Entity<Orcanode>()
-                .ToContainer("Orcanode")
+                .ToContainer(environment + "Orcanode")
                 .HasPartitionKey(item => item.PartitionValue)
                 .HasKey(item=>item.ID);
 
             modelBuilder.Entity<OrcanodeEvent>()
-                .ToContainer("OrcanodeEvent")
+                .ToContainer(environment + "OrcanodeEvent")
                 .Property(item => item.Year)
                 .HasConversion<string>();
 
             modelBuilder.Entity<OrcanodeEvent>()
-                .ToContainer("OrcanodeEvent")
+                .ToContainer(environment + "OrcanodeEvent")
                 .HasPartitionKey(item => item.Year)
                 .HasOne(item => item.Orcanode)
                 .WithMany()


### PR DESCRIPTION
Read the environment variable and use it as a prefix for the container name.
Treat "Production" as the empty prefix, so as to use the existing containers.

Fixes #197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Container names for entities are now dynamically adjusted based on the environment, enhancing flexibility for different deployment scenarios.
- **Bug Fixes**
	- Resolved potential issues with container naming in production environments by ensuring no prefixes are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->