### PR TITLE
Add basic cosmos test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,12 @@ jobs:
           cancel_others: 'false'
           paths_ignore: '["**.md"]'
 
+      - name: Set environment variables
+        if: steps.skip_check.outputs.should_skip != 'true'
+        run: |
+           echo "AZURE_COSMOS_CONNECTIONSTRING=${{ secrets.AZURE_COSMOS_CONNECTIONSTRING }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+           echo "AZURE_COSMOS_DATABASENAME=${{ secrets.AZURE_COSMOS_DATABASENAME }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4.2.1
         if: steps.skip_check.outputs.should_skip != 'true'
         with:

--- a/OrcanodeMonitor/Data/OrcanodeMonitorContext.cs
+++ b/OrcanodeMonitor/Data/OrcanodeMonitorContext.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) Orcanode Monitor contributors
+// SPDX-License-Identifier: MIT
+
 using Microsoft.EntityFrameworkCore;
 using OrcanodeMonitor.Models;
 

--- a/Test/CosmosTests.cs
+++ b/Test/CosmosTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Orcanode Monitor contributors
+// SPDX-License-Identifier: MIT
+
+// Tests in this file require the following Repository Secrets to be configured
+// if running in github, or environment variables to be configured if running locally:
+// AZURE_COSMOS_CONNECTIONSTRING
+// AZURE_COSMOS_DATABASENAME
+
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Mono.TextTemplating;
+using OrcanodeMonitor.Data;
+
+namespace Test
+{
+    public class ProductionOrcanodeMonitorContext : OrcanodeMonitorContext
+    {
+        public ProductionOrcanodeMonitorContext(DbContextOptions<OrcanodeMonitorContext> options)
+            : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            // Production specific configurations
+        }
+    }
+
+    public class StagingOrcanodeMonitorContext : OrcanodeMonitorContext
+    {
+        public StagingOrcanodeMonitorContext(DbContextOptions<OrcanodeMonitorContext> options)
+            : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            // Staging specific configurations
+        }
+    }
+
+    public class DevelopmentOrcanodeMonitorContext : OrcanodeMonitorContext
+    {
+        public DevelopmentOrcanodeMonitorContext(DbContextOptions<OrcanodeMonitorContext> options)
+            : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            // Staging specific configurations
+        }
+    }
+
+
+    [TestClass]
+    public class CosmosTests
+    {
+        private DbContextOptions<OrcanodeMonitorContext> GetCosmosDbContextOptions()
+        {
+            // Code to set connection and databaseName duplicated from Program.cs.
+            // TODO: Should be moved to a common location.
+            var connection = Environment.GetEnvironmentVariable("AZURE_COSMOS_CONNECTIONSTRING");
+            if (connection.IsNullOrEmpty())
+            {
+                throw new InvalidOperationException("AZURE_COSMOS_CONNECTIONSTRING not found.");
+            }
+            string databaseName = Environment.GetEnvironmentVariable("AZURE_COSMOS_DATABASENAME") ?? "orcasound-cosmosdb";
+            if (databaseName.IsNullOrEmpty())
+            {
+                throw new InvalidOperationException("AZURE_COSMOS_DATABASENAME not found.");
+            }
+
+            return new DbContextOptionsBuilder<OrcanodeMonitorContext>()
+                .UseCosmos(
+                    connection,
+                    databaseName: databaseName,
+                    options => { options.ConnectionMode(ConnectionMode.Gateway); }).Options;
+        }
+
+        private void VerifyCanReadEntity<T>(DbSet<T> dbSet, string entityName) where T : class
+        {
+            var items = dbSet.ToList();
+            Assert.IsNotNull(items, $"{entityName} should not be null");
+            // Add specific assertions based on expected test data
+        }
+
+        [TestMethod]
+        public void CanReadProduction()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+
+            var options = GetCosmosDbContextOptions();
+            using (OrcanodeMonitorContext context = new ProductionOrcanodeMonitorContext(options))
+            {
+                Assert.IsNotNull(context, "Context initialization failed");
+
+                VerifyCanReadEntity(context.MonitorState, "MonitorState");
+                VerifyCanReadEntity(context.Orcanodes, "Orcanodes");
+                VerifyCanReadEntity(context.OrcanodeEvents, "OrcanodeEvents");
+            }
+        }
+
+        [TestMethod]
+        public void CanReadStaging()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Staging");
+
+            var options = GetCosmosDbContextOptions();
+            using (OrcanodeMonitorContext context = new StagingOrcanodeMonitorContext(options))
+            {
+                Assert.IsNotNull(context, "Context initialization failed");
+
+                VerifyCanReadEntity(context.MonitorState, "MonitorState");
+                VerifyCanReadEntity(context.Orcanodes, "Orcanodes");
+                VerifyCanReadEntity(context.OrcanodeEvents, "OrcanodeEvents");
+            }
+        }
+
+        [TestMethod]
+        public void CanReadDevelopment()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+
+            var options = GetCosmosDbContextOptions();
+            using (OrcanodeMonitorContext context = new DevelopmentOrcanodeMonitorContext(options))
+            {
+                Assert.IsNotNull(context, "Context initialization failed");
+
+                VerifyCanReadEntity(context.MonitorState, "MonitorState");
+                VerifyCanReadEntity(context.Orcanodes, "Orcanodes");
+                VerifyCanReadEntity(context.OrcanodeEvents, "OrcanodeEvents");
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Introduced a new suite of unit tests for the OrcanodeMonitorContext class, ensuring reliable data retrieval from Azure Cosmos DB across Production, Staging, and Development environments.
	- Added tests to verify the ability to read MonitorState, Orcanodes, and OrcanodeEvents collections.
- **Chores**
	- Streamlined the OrcanodeMonitorContext.cs file by adding a copyright notice and removing unused directives.
- **Chores**
	- Enhanced the GitHub Actions workflow for Continuous Integration by adding a step to set environment variables for Azure Cosmos DB connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->