### PR TITLE
Add utility to transfer data between cosmos database instances

### DIFF
--- a/OrcanodeMonitor.sln
+++ b/OrcanodeMonitor.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrcanodeMonitor", "Orcanode
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", "{4365DC87-DDDA-469A-8503-A4DE8A9DD29C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransferData", "TransferData\TransferData.csproj", "{6782AD7D-54FE-4CBC-B1FA-2C43345EB07F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{4365DC87-DDDA-469A-8503-A4DE8A9DD29C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4365DC87-DDDA-469A-8503-A4DE8A9DD29C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4365DC87-DDDA-469A-8503-A4DE8A9DD29C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6782AD7D-54FE-4CBC-B1FA-2C43345EB07F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6782AD7D-54FE-4CBC-B1FA-2C43345EB07F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6782AD7D-54FE-4CBC-B1FA-2C43345EB07F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6782AD7D-54FE-4CBC-B1FA-2C43345EB07F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TransferData/Program.cs
+++ b/TransferData/Program.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json.Linq;
+using OrcanodeMonitor.Core;
+using OrcanodeMonitor.Data;
+using OrcanodeMonitor.Models;
+using System;
+
+namespace OrcanodeMonitor
+{
+    public class FromOrcanodeMonitorContext : OrcanodeMonitorContext
+    {
+        public FromOrcanodeMonitorContext(DbContextOptions<OrcanodeMonitorContext> options)
+            : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            // Staging specific configurations
+        }
+    }
+
+    public class ToOrcanodeMonitorContext : OrcanodeMonitorContext
+    {
+        public ToOrcanodeMonitorContext(DbContextOptions<OrcanodeMonitorContext> options)
+            : base(options) { }
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            // Staging specific configurations
+        }
+    }
+
+    public class Program
+    {
+        private static string toConnection = "<to be filled in>";
+        private static string fromConnection = "<to be filled in>";
+        private static string databaseName = Environment.GetEnvironmentVariable("AZURE_COSMOS_DATABASENAME") ?? "orcasound-cosmosdb";
+
+        public static async Task Main(string[] args)
+        {
+            if (string.IsNullOrEmpty(databaseName))
+            {
+                throw new InvalidOperationException("AZURE_COSMOS_DATABASENAME not found.");
+            }
+
+            var fromOptions = CreateDbContextOptions(fromConnection);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+            using (OrcanodeMonitorContext fromContext = new FromOrcanodeMonitorContext(fromOptions))
+            {
+                // Force model creation.
+                List<Orcanode> fromNodes = fromContext.Orcanodes.ToList();
+
+                var toOptions = CreateDbContextOptions(toConnection);
+                Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+                using (OrcanodeMonitorContext toContext = new ToOrcanodeMonitorContext(toOptions))
+                {
+                    await TransferDataAsync(fromContext, toContext);
+                }
+            }
+        }
+
+        private static DbContextOptions<OrcanodeMonitorContext> CreateDbContextOptions(string connectionString)
+        {
+            return new DbContextOptionsBuilder<OrcanodeMonitorContext>()
+                        .UseCosmos(
+                            connectionString,
+                            databaseName: databaseName,
+                            options => { options.ConnectionMode(ConnectionMode.Gateway); }).Options;
+        }
+
+        private static bool IsCovered(OrcanodeEvent item, List<OrcanodeEvent> items)
+        {
+            var all = items.Where(i => i.NodeName == item.NodeName && i.Type == item.Type);
+            OrcanodeEvent before = all.Where(i => i.DateTimeUtc <= item.DateTimeUtc).OrderByDescending(i => i.DateTimeUtc).FirstOrDefault();
+            if (before == null)
+            {
+                return false;
+            }
+            if (before.Value != item.Value)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        private static async Task TransferDataAsync(OrcanodeMonitorContext fromContext, OrcanodeMonitorContext toContext)
+        {
+            List<Orcanode> fromNodes = fromContext.Orcanodes.Where(n => n.OrcasoundHost != "dev.orcasound.net").ToList();
+            List<Orcanode> toNodes = toContext.Orcanodes.Where(n => n.OrcasoundHost != "dev.orcasound.net").ToList();
+            List<OrcanodeEvent> fromItems = fromContext.OrcanodeEvents.ToList();
+            List<OrcanodeEvent> toItems = toContext.OrcanodeEvents.ToList();
+
+            foreach (OrcanodeEvent fromItem in fromItems)
+            {
+                if (fromItem.Orcanode == null)
+                {
+                    continue;
+                }
+                if (!fromNodes.Contains(fromItem.Orcanode))
+                {
+                    continue;
+                }
+                if (IsCovered(fromItem, toItems))
+                {
+                    continue;
+                }
+
+                Console.WriteLine(fromItem.Description);
+
+                // Create an equivalent "to" event.
+                Orcanode? toNode = toNodes.Where(n => n.DisplayName == fromItem.NodeName).FirstOrDefault();
+                if (toNode == null)
+                {
+                    continue;
+                }
+                OrcanodeEvent toEvent = new OrcanodeEvent(toNode, fromItem.Type, fromItem.Value, fromItem.DateTimeUtc);
+                toContext.OrcanodeEvents.Add(toEvent);
+            }
+            await toContext.SaveChangesAsync();
+            Console.WriteLine("Data transfer complete.");
+        }
+    }
+}

--- a/TransferData/TransferData.csproj
+++ b/TransferData/TransferData.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrcanodeMonitor\OrcanodeMonitor.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new project, "TransferData," to facilitate data transfer within the OrcanodeMonitor system.
	- Added a data transfer application that connects to Azure Cosmos DB and manages data staging configurations.

- **Bug Fixes**
	- Enhanced data transfer logic to ensure events are not duplicated in the destination context.

- **Documentation**
	- Updated project structure and configuration settings for better clarity and integration within the existing solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->