### PR TITLE
Improvements to node specific page

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -738,8 +738,8 @@ namespace OrcanodeMonitor.Core
 
         public class TimestampResult
         {
-            public string UnixTimestampString;
-            public DateTimeOffset? Offset;
+            public string UnixTimestampString = string.Empty;
+            public DateTimeOffset? Offset = null;
         }
 
         public async static Task<TimestampResult?> GetLatestS3TimestampAsync(Orcanode node, bool updateNode, ILogger logger)
@@ -748,6 +748,8 @@ namespace OrcanodeMonitor.Core
             using HttpResponseMessage response = await _httpClient.GetAsync(url);
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
+                logger.LogError($"{node.S3NodeName} not found on S3");
+
                 // Absent.
                 if (updateNode)
                 {
@@ -757,6 +759,8 @@ namespace OrcanodeMonitor.Core
             }
             if (response.StatusCode == HttpStatusCode.Forbidden)
             {
+                logger.LogError($"{node.S3NodeName} got access denied on S3");
+
                 // Access denied.
                 if (updateNode)
                 {
@@ -766,6 +770,8 @@ namespace OrcanodeMonitor.Core
             }
             if (!response.IsSuccessStatusCode)
             {
+                logger.LogError($"{node.S3NodeName} got status {response.StatusCode} on S3");
+
                 return null;
             }
 

--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -738,8 +738,13 @@ namespace OrcanodeMonitor.Core
 
         public class TimestampResult
         {
-            public string UnixTimestampString = string.Empty;
-            public DateTimeOffset? Offset = null;
+            public string UnixTimestampString { get; }
+            public DateTimeOffset? Offset { get; }
+            public TimestampResult(string unixTimestampString, DateTimeOffset? offset)
+            {
+                UnixTimestampString = unixTimestampString;
+                Offset = offset;
+            }
         }
 
         public async static Task<TimestampResult?> GetLatestS3TimestampAsync(Orcanode node, bool updateNode, ILogger logger)
@@ -777,9 +782,7 @@ namespace OrcanodeMonitor.Core
 
             string content = await response.Content.ReadAsStringAsync();
             string unixTimestampString = content.TrimEnd();
-            var result = new TimestampResult();
-            result.UnixTimestampString = unixTimestampString;
-            result.Offset = response.Content.Headers.LastModified;
+            var result = new TimestampResult(unixTimestampString, response.Content.Headers.LastModified);
             return result;
         }
 

--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -21,6 +21,7 @@ using Newtonsoft.Json.Linq;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Diagnostics;
 
 namespace OrcanodeMonitor.Core
 {
@@ -735,6 +736,47 @@ namespace OrcanodeMonitor.Core
             return unixTime;
         }
 
+        public class TimestampResult
+        {
+            public string UnixTimestampString;
+            public DateTimeOffset? Offset;
+        }
+
+        public async static Task<TimestampResult?> GetLatestS3TimestampAsync(Orcanode node, bool updateNode, ILogger logger)
+        {
+            string url = "https://" + node.S3Bucket + ".s3.amazonaws.com/" + node.S3NodeName + "/latest.txt";
+            using HttpResponseMessage response = await _httpClient.GetAsync(url);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Absent.
+                if (updateNode)
+                {
+                    node.LatestRecordedUtc = null;
+                }
+                return null;
+            }
+            if (response.StatusCode == HttpStatusCode.Forbidden)
+            {
+                // Access denied.
+                if (updateNode)
+                {
+                    node.LatestRecordedUtc = DateTime.MinValue;
+                }
+                return null;
+            }
+            if (!response.IsSuccessStatusCode)
+            {
+                return null;
+            }
+
+            string content = await response.Content.ReadAsStringAsync();
+            string unixTimestampString = content.TrimEnd();
+            var result = new TimestampResult();
+            result.UnixTimestampString = unixTimestampString;
+            result.Offset = response.Content.Headers.LastModified;
+            return result;
+        }
+
         /// <summary>
         /// Update the timestamps for a given Orcanode by querying files on S3.
         /// </summary>
@@ -744,33 +786,18 @@ namespace OrcanodeMonitor.Core
         /// <returns></returns>
         public async static Task UpdateS3DataAsync(OrcanodeMonitorContext context, Orcanode node, ILogger logger)
         {
-            string url = "https://" + node.S3Bucket + ".s3.amazonaws.com/" + node.S3NodeName + "/latest.txt";
-            using HttpResponseMessage response = await _httpClient.GetAsync(url);
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                // Absent.
-                node.LatestRecordedUtc = null;
-                return;
-            }
-            if (response.StatusCode == HttpStatusCode.Forbidden)
-            {
-                // Access denied.
-                node.LatestRecordedUtc = DateTime.MinValue;
-                return;
-            }
-            if (!response.IsSuccessStatusCode)
+            TimestampResult? result = await GetLatestS3TimestampAsync(node, true, logger);
+            if (result == null)
             {
                 return;
             }
-
-            string content = await response.Content.ReadAsStringAsync();
-            string unixTimestampString = content.TrimEnd();
+            string unixTimestampString = result.UnixTimestampString;
             DateTime? latestRecorded = UnixTimeStampStringToDateTimeUtc(unixTimestampString);
             if (latestRecorded.HasValue)
             {
                 node.LatestRecordedUtc = latestRecorded?.ToUniversalTime();
 
-                DateTimeOffset? offset = response.Content.Headers.LastModified;
+                DateTimeOffset? offset = result.Offset;
                 if (offset.HasValue)
                 {
                     node.LatestUploadedUtc = offset.Value.UtcDateTime;
@@ -864,15 +891,7 @@ namespace OrcanodeMonitor.Core
             AddOrcanodeEvent(context, node, OrcanodeEventTypes.HydrophoneStream, value);
         }
 
-        /// <summary>
-        /// Update the ManifestUpdated timestamp for a given Orcanode by querying S3.
-        /// </summary>
-        /// <param name="context">Database context</param>
-        /// <param name="node">Orcanode to update</param>
-        /// <param name="unixTimestampString">Value in the latest.txt file</param>
-        /// <param name="logger">Logger</param>
-        /// <returns></returns>
-        public async static Task UpdateManifestTimestampAsync(OrcanodeMonitorContext context, Orcanode node, string unixTimestampString, ILogger logger)
+        public async static Task<FrequencyInfo?> GetLatestAudioSampleAsync(Orcanode node, string unixTimestampString, bool updateNode, ILogger logger)
         {
             OrcanodeOnlineStatus oldStatus = node.S3StreamStatus;
 
@@ -880,18 +899,24 @@ namespace OrcanodeMonitor.Core
             using HttpResponseMessage response = await _httpClient.GetAsync(url);
             if (!response.IsSuccessStatusCode)
             {
-                return;
+                return null;
             }
 
             DateTimeOffset? offset = response.Content.Headers.LastModified;
             if (!offset.HasValue)
             {
-                node.LastCheckedUtc = DateTime.UtcNow;
-                return;
+                if (updateNode)
+                {
+                    node.LastCheckedUtc = DateTime.UtcNow;
+                }
+                return null;
             }
 
-            node.ManifestUpdatedUtc = offset.Value.UtcDateTime;
-            node.LastCheckedUtc = DateTime.UtcNow;
+            if (updateNode)
+            {
+                node.ManifestUpdatedUtc = offset.Value.UtcDateTime;
+                node.LastCheckedUtc = DateTime.UtcNow;
+            }
 
             // Download manifest.
             Uri baseUri = new Uri(url);
@@ -908,14 +933,38 @@ namespace OrcanodeMonitor.Core
             try
             {
                 using Stream stream = await _httpClient.GetStreamAsync(newUri);
-                node.AudioStreamStatus = await FfmpegCoreAnalyzer.AnalyzeAudioStreamAsync(stream, oldStatus);
-                node.AudioStandardDeviation = 0.0;
-            } catch (Exception ex)
+                FrequencyInfo frequencyInfo = await FfmpegCoreAnalyzer.AnalyzeAudioStreamAsync(stream, oldStatus);
+                return frequencyInfo;
+            }
+            catch (Exception ex)
             {
                 // We couldn't fetch the stream audio so could not update the
                 // audio standard deviation. Just ignore this for now.
                 logger.LogError(ex, "Exception in UpdateManifestTimestampAsync");
             }
+            return null;
+        }
+
+        /// <summary>
+        /// Update the ManifestUpdated timestamp for a given Orcanode by querying S3.
+        /// </summary>
+        /// <param name="context">Database context</param>
+        /// <param name="node">Orcanode to update</param>
+        /// <param name="unixTimestampString">Value in the latest.txt file</param>
+        /// <param name="logger">Logger</param>
+        /// <returns></returns>
+        public async static Task UpdateManifestTimestampAsync(OrcanodeMonitorContext context, Orcanode node, string unixTimestampString, ILogger logger)
+        {
+            OrcanodeOnlineStatus oldStatus = node.S3StreamStatus;
+
+            FrequencyInfo? frequencyInfo = await GetLatestAudioSampleAsync(node, unixTimestampString, true, logger);
+            if (frequencyInfo == null)
+            {
+                return;
+            }
+
+            node.AudioStreamStatus = frequencyInfo.Status;
+            node.AudioStandardDeviation = 0.0;
 
             OrcanodeOnlineStatus newStatus = node.S3StreamStatus;
             if (newStatus != oldStatus)

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml
@@ -5,7 +5,14 @@
 }
 
 <div class="text-center">
-    <h1 class="display-4">Node Events</h1>
+    <h1 class="display-4">@Model.NodeName</h1>
+
+    <!-- Navigation Button -->
+    <button onclick="location.href='@Url.Page("/SpectralDensity", new { id = Model.Id })'" class="btn btn-primary">
+        View Most Recent Spectral Density
+    </button>
+    <p></p>
+
     <form method="post">
         @Html.AntiForgeryToken()
         <input type="hidden" name="eventType" value="@Model.EventType" />

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml
@@ -14,7 +14,15 @@
     <p></p>
 
     <div>
-        Uptime percentage: @Model.UptimePercentage%
+        Uptime percentage:
+        <span id="uptime-all-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("all", "pastWeek")%</span>
+        <span id="uptime-hydrophoneStream-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "pastWeek")%</span>
+        <span id="uptime-dataplicityConnection-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "pastWeek")%</span>
+        <span id="uptime-mezmoLogging-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "pastWeek")%</span>
+        <span id="uptime-all-pastMonth" class="uptime-percentage">@Model.GetUptimePercentage("all", "pastMonth")%</span>
+        <span id="uptime-hydrophoneStream-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "pastMonth")%</span>
+        <span id="uptime-dataplicityConnection-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "pastMonth")%</span>
+        <span id="uptime-mezmoLogging-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "pastMonth")%</span>
         <p></p>
     </div>
 
@@ -22,7 +30,7 @@
     <div>
         Filter by Time Range:
         <button id="btn-timeRange-pastWeek" class="btn unselected" onclick="updateFilter('timeRange', 'pastWeek')">Past Week</button>
-        <button id="btn-timeRange-allTime" class="btn selected" onclick="updateFilter('timeRange', 'allTime')">Past Month</button>
+        <button id="btn-timeRange-pastMonth" class="btn selected" onclick="updateFilter('timeRange', 'pastMonth')">Past Month</button>
         <p></p>
     </div>
 
@@ -62,7 +70,7 @@
 
     <script>
         var currentFilters = {
-            timeRange: 'allTime',
+            timeRange: 'pastMonth',
             type: 'all' };
 
         function updateFilter(filterType, filterValue) {
@@ -97,6 +105,7 @@
             }
 
             filterTable();
+            showUptimePercentage("uptime-" + currentFilters.type + "-" + currentFilters.timeRange);
         }
 
         function filterTable() {
@@ -106,7 +115,7 @@
             // Loop through each row.
             rows.forEach(function(row) {
                 // Check if the row matches the selected time range and type
-                var matchesTimeRange = (currentFilters.timeRange === 'allTime' || row.classList.contains(currentFilters.timeRange));
+                var matchesTimeRange = (currentFilters.timeRange === 'pastMonth' || row.classList.contains(currentFilters.timeRange));
                 var matchesType = (currentFilters.type === 'all' || row.classList.contains(currentFilters.type));
                 
                 if (matchesTimeRange && matchesType) {
@@ -115,6 +124,17 @@
                     row.style.display = 'none'; // Hide non-matching rows.
                 }
             });
+        }
+
+        function showUptimePercentage(id) {
+            // Hide all uptime percentage elements.
+            var elements = document.querySelectorAll('.uptime-percentage');
+            elements.forEach(function(element) {
+                element.style.display = 'none';
+            });
+
+            // Show the selected uptime percentage.
+            document.getElementById(id).style.display = '';
         }
     </script>
 </div>

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml
@@ -13,55 +13,30 @@
     </button>
     <p></p>
 
-    <form method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" name="eventType" value="@Model.EventType" />
-        <input type="hidden" name="Id" value="@Model.Id" />
-        <div role="group" aria-label="Time period selection">
-            <button type="submit" name="timePeriod" value="week"
-                    class="btn @(Model.TimePeriod == "week" ? "selected" : "unselected")"
-                    aria-pressed="@(Model.TimePeriod == "week" ? "true" : "false")" >
-                Past Week
-            </button>
-            <button type="submit" name="timePeriod" value="month"
-                    class="btn @(Model.TimePeriod == "month" ? "selected" : "unselected")"
-                    aria-pressed="@(Model.TimePeriod == "month" ? "true" : "false")">
-                Past Month
-            </button>
-        </div>
-    </form>
-    <p/>
-    <form method="post">
-        @Html.AntiForgeryToken()
-        <input type="hidden" name="timePeriod" value="@Model.TimePeriod" />
-        <input type="hidden" name="Id" value="@Model.Id" />
-        <div role="group" aria-label="Event type selection">
-            <button type="submit" name="eventType" value="all"
-                    class="btn @(Model.EventType == "all" ? "selected" : "unselected")"
-                    aria-pressed="@(Model.EventType == "all" ? "true" : "false")">
-                All
-            </button>
-            <button type="submit" name="eventType" value="hydrophone stream"
-                    class="btn @(Model.EventType == "hydrophone stream" ? "selected" : "unselected")"
-                    aria-pressed="@(Model.EventType == "hydrophone stream" ? "true" : "false")">
-                Hydrophone Stream
-            </button>
-            <button type="submit" name="eventType" value="dataplicity connection"
-                    class="btn @(Model.EventType == "dataplicity connection" ? "selected" : "unselected")"
-                    aria-pressed="@(Model.EventType == "dataplicity connection" ? "true" : "false")">
-                Dataplicity Connection
-            </button>
-            <button type="submit" name="eventType" value="Mezmo logging"
-                    class="btn @(Model.EventType == "Mezmo logging" ? "selected" : "unselected")"
-                    aria-pressed="@(Model.EventType == "Mezmo logging" ? "true" : "false")">
-                Mezmo Logging
-            </button>
-        </div>
-    </form>
-    <p>
+    <div>
         Uptime percentage: @Model.UptimePercentage%
-    </p>
-    <table class="table">
+        <p></p>
+    </div>
+
+    <!-- Filter Buttons for Time Range -->
+    <div>
+        Filter by Time Range:
+        <button id="btn-timeRange-pastWeek" class="btn unselected" onclick="updateFilter('timeRange', 'pastWeek')">Past Week</button>
+        <button id="btn-timeRange-allTime" class="btn selected" onclick="updateFilter('timeRange', 'allTime')">Past Month</button>
+        <p></p>
+    </div>
+
+    <!-- Filter Buttons for Type -->
+    <div>
+        Filter by Type:
+        <button id="btn-type-all" class="btn selected" onclick="updateFilter('type', 'all')">All</button>
+        <button id="btn-type-hydrophoneStream" class="btn unselected" onclick="updateFilter('type', 'hydrophoneStream')">Hydrophone Stream</button>
+        <button id="btn-type-dataplicityConnection" class="btn unselected" onclick="updateFilter('type', 'dataplicityConnection')">Dataplicity Connection</button>
+        <button id="btn-type-mezmoLogging" class="btn unselected" onclick="updateFilter('type', 'mezmoLogging')">Mezmo Logging</button>
+        <p></p>
+    </div>
+
+    <table id="eventsTable" class="table">
         <thead>
             <tr>
                 <th>Timestamp (Pacific)</th>
@@ -77,11 +52,69 @@
             }
             @foreach (Models.OrcanodeEvent item in Model.RecentEvents)
             {
-                <tr>
+                <tr class="@Model.GetEventClasses(item)">
                     <td>@item.DateTimeLocal.ToString("g")</td>
                     <td align="left">@item.Description</td>
                 </tr>
             }
         </tbody>
     </table>
+
+    <script>
+        var currentFilters = {
+            timeRange: 'allTime',
+            type: 'all' };
+
+        function updateFilter(filterType, filterValue) {
+            // Update time range filter.
+            if (filterType == 'timeRange') {
+                var oldTimeRangeButtonId = 'btn-timeRange-' + currentFilters.timeRange;
+                var oldTimeRangeButton = document.getElementById(oldTimeRangeButtonId);
+                oldTimeRangeButton.classList.remove('selected');
+                oldTimeRangeButton.classList.add('unselected');
+
+                currentFilters.timeRange = filterValue;
+
+                var newTimeRangeButtonId = 'btn-timeRange-' + currentFilters.timeRange;
+                var newTimeRangeButton = document.getElementById(newTimeRangeButtonId);
+                newTimeRangeButton.classList.remove('unselected');
+                newTimeRangeButton.classList.add('selected');
+            }
+            
+            // Update type filter.
+            if (filterType == 'type') {
+                var oldTypeButtonId = 'btn-type-' + currentFilters.type;
+                var oldTypeButton = document.getElementById(oldTypeButtonId);
+                oldTypeButton.classList.remove('selected');
+                oldTypeButton.classList.add('unselected');
+
+                currentFilters.type = filterValue;
+
+                var newTypeButtonId = 'btn-type-' + currentFilters.type;
+                var newTypeButton = document.getElementById(newTypeButtonId);
+                newTypeButton.classList.remove('unselected');
+                newTypeButton.classList.add('selected');
+            }
+
+            filterTable();
+        }
+
+        function filterTable() {
+            // Get all rows from the table.
+            var rows = document.querySelectorAll('#eventsTable tbody tr');
+            
+            // Loop through each row.
+            rows.forEach(function(row) {
+                // Check if the row matches the selected time range and type
+                var matchesTimeRange = (currentFilters.timeRange === 'allTime' || row.classList.contains(currentFilters.timeRange));
+                var matchesType = (currentFilters.type === 'all' || row.classList.contains(currentFilters.type));
+                
+                if (matchesTimeRange && matchesType) {
+                    row.style.display = ''; // Show matching rows.
+                } else {
+                    row.style.display = 'none'; // Hide non-matching rows.
+                }
+            });
+        }
+    </script>
 </div>

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -48,36 +48,44 @@ namespace OrcanodeMonitor.Pages
             FetchEvents(_logger);
         }
 
-        public IActionResult OnPost(string timePeriod, string eventType, string id)
+        public string GetTypeClass(OrcanodeEvent item)
         {
-            if (string.IsNullOrEmpty(id))
+            if (item.Type == OrcanodeEventTypes.HydrophoneStream)
             {
-                _logger.LogError("Node ID cannot be empty");
-                return BadRequest("Invalid node ID");
+                return "hydrophoneStream";
             }
-            if (timePeriod.IsNullOrEmpty())
+            else if (item.Type == OrcanodeEventTypes.DataplicityConnection)
             {
-                timePeriod = TimePeriod;
+                return "dataplicityConnection";
             }
-            if (eventType.IsNullOrEmpty())
+            else if (item.Type == OrcanodeEventTypes.MezmoLogging)
             {
-                eventType = EventType;
+                return "mezmoLogging";
             }
-            if (timePeriod != "week" && timePeriod != "month")
+            else if (item.Type == OrcanodeEventTypes.AgentUpgradeStatus)
             {
-                _logger.LogWarning($"Invalid time range selected: {timePeriod}");
-                return BadRequest("Invalid time range");
+                return "agentUpgradeStatus";
             }
-            if (eventType != OrcanodeEventTypes.All && eventType != OrcanodeEventTypes.HydrophoneStream && eventType != OrcanodeEventTypes.MezmoLogging && eventType != OrcanodeEventTypes.DataplicityConnection)
+            else if (item.Type == OrcanodeEventTypes.SDCardSize)
             {
-                _logger.LogWarning($"Invalid event type selected: {eventType}");
-                return BadRequest("Invalid event type");
+                return "sdCardSize";
             }
-            TimePeriod = timePeriod;
-            EventType = eventType;
-            _node = _databaseContext.Orcanodes.Where(n => n.ID == id).First();
-            FetchEvents(_logger);
-            return Page();
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        public string GetTimeRangeClass(OrcanodeEvent item)
+        {
+            DateTime OneWeekAgo = DateTime.UtcNow.AddDays(-7);
+            return (item.DateTimeUtc > OneWeekAgo) ? "pastWeek" : string.Empty;
+        }
+
+        public string GetEventClasses(OrcanodeEvent item)
+        {
+            string classes = GetTypeClass(item) + " " + GetTimeRangeClass(item);
+            return classes;
         }
     }
 }

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -28,7 +28,18 @@ namespace OrcanodeMonitor.Pages
         private DateTime SinceTime => (TimePeriod == "week") ? DateTime.UtcNow.AddDays(-7) : DateTime.UtcNow.AddMonths(-1);
         private List<OrcanodeEvent> _events;
         public List<OrcanodeEvent> RecentEvents => _events;
-        public int UptimePercentage => Orcanode.GetUptimePercentage(Id, _events, SinceTime, (EventType == OrcanodeEventTypes.All) ? OrcanodeEventTypes.HydrophoneStream : EventType);
+        public int GetUptimePercentage(string type, string timeRange)
+        {
+            DateTime sinceTime = (timeRange == "pastWeek") ? DateTime.UtcNow.AddDays(-7) : DateTime.UtcNow.AddMonths(-1);
+            string eventType = type switch
+            {
+                "hydrophoneStream" => OrcanodeEventTypes.HydrophoneStream,
+                "dataplicityConnection" => OrcanodeEventTypes.DataplicityConnection,
+                "mezmoLogging" => OrcanodeEventTypes.MezmoLogging,
+                _ => OrcanodeEventTypes.HydrophoneStream
+            };
+            return Orcanode.GetUptimePercentage(Id, _events, sinceTime, eventType);
+        }
 
         public NodeEventsModel(OrcanodeMonitorContext context, ILogger<NodeEventsModel> logger)
         {

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -1,13 +1,10 @@
 // Copyright (c) Orcanode Monitor contributors
 // SPDX-License-Identifier: MIT
-using MathNet.Numerics.Statistics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.IdentityModel.Tokens;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
-using System.Xml.Linq;
 using static OrcanodeMonitor.Core.Fetcher;
 
 namespace OrcanodeMonitor.Pages
@@ -50,7 +47,9 @@ namespace OrcanodeMonitor.Pages
 
         private void FetchEvents(ILogger logger)
         {
-            _events = Fetcher.GetRecentEventsForNode(_databaseContext, Id, SinceTime, logger).Where(e => e.Type == EventType || EventType == OrcanodeEventTypes.All).ToList() ?? new List<OrcanodeEvent>();
+            _events = Fetcher.GetRecentEventsForNode(_databaseContext, Id, SinceTime, logger)
+                .Where(e => e.Type == EventType || EventType == OrcanodeEventTypes.All)
+                .ToList() ?? new List<OrcanodeEvent>();
         }
 
         public async Task OnGetAsync(string id)

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -48,33 +48,15 @@ namespace OrcanodeMonitor.Pages
             FetchEvents(_logger);
         }
 
-        public string GetTypeClass(OrcanodeEvent item)
+        public string GetTypeClass(OrcanodeEvent item) => item.Type switch
         {
-            if (item.Type == OrcanodeEventTypes.HydrophoneStream)
-            {
-                return "hydrophoneStream";
-            }
-            else if (item.Type == OrcanodeEventTypes.DataplicityConnection)
-            {
-                return "dataplicityConnection";
-            }
-            else if (item.Type == OrcanodeEventTypes.MezmoLogging)
-            {
-                return "mezmoLogging";
-            }
-            else if (item.Type == OrcanodeEventTypes.AgentUpgradeStatus)
-            {
-                return "agentUpgradeStatus";
-            }
-            else if (item.Type == OrcanodeEventTypes.SDCardSize)
-            {
-                return "sdCardSize";
-            }
-            else
-            {
-                return string.Empty;
-            }
-        }
+            OrcanodeEventTypes.HydrophoneStream => "hydrophoneStream",
+            OrcanodeEventTypes.DataplicityConnection => "dataplicityConnection",
+            OrcanodeEventTypes.MezmoLogging => "mezmoLogging",
+            OrcanodeEventTypes.AgentUpgradeStatus => "agentUpgradeStatus",
+            OrcanodeEventTypes.SDCardSize => "sdCardSize",
+            _ => string.Empty
+        };
 
         public string GetTimeRangeClass(OrcanodeEvent item)
         {

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Orcanode Monitor contributors
 // SPDX-License-Identifier: MIT
+using MathNet.Numerics.Statistics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.IdentityModel.Tokens;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
+using System.Xml.Linq;
+using static OrcanodeMonitor.Core.Fetcher;
 
 namespace OrcanodeMonitor.Pages
 {
@@ -13,8 +16,9 @@ namespace OrcanodeMonitor.Pages
     {
         private readonly OrcanodeMonitorContext _databaseContext;
         private readonly ILogger<NodeEventsModel> _logger;
-        private string _nodeId;
-        public string Id => _nodeId;
+        private Orcanode? _node = null;
+        public string Id => _node?.ID ?? string.Empty;
+        public string NodeName => _node?.DisplayName ?? "Unknown";
 
         [BindProperty]
         public string TimePeriod { get; set; } = "week"; // Default to 'week'
@@ -24,24 +28,23 @@ namespace OrcanodeMonitor.Pages
         private DateTime SinceTime => (TimePeriod == "week") ? DateTime.UtcNow.AddDays(-7) : DateTime.UtcNow.AddMonths(-1);
         private List<OrcanodeEvent> _events;
         public List<OrcanodeEvent> RecentEvents => _events;
-        public int UptimePercentage => Orcanode.GetUptimePercentage(_nodeId, _events, SinceTime, (EventType == OrcanodeEventTypes.All) ? OrcanodeEventTypes.HydrophoneStream : EventType);
+        public int UptimePercentage => Orcanode.GetUptimePercentage(Id, _events, SinceTime, (EventType == OrcanodeEventTypes.All) ? OrcanodeEventTypes.HydrophoneStream : EventType);
 
         public NodeEventsModel(OrcanodeMonitorContext context, ILogger<NodeEventsModel> logger)
         {
             _databaseContext = context;
             _logger = logger;
-            _nodeId = string.Empty;
             _events = new List<OrcanodeEvent>();
         }
 
         private void FetchEvents(ILogger logger)
         {
-            _events = Fetcher.GetRecentEventsForNode(_databaseContext, _nodeId, SinceTime, logger).Where(e => e.Type == EventType || EventType == OrcanodeEventTypes.All).ToList() ?? new List<OrcanodeEvent>();
+            _events = Fetcher.GetRecentEventsForNode(_databaseContext, Id, SinceTime, logger).Where(e => e.Type == EventType || EventType == OrcanodeEventTypes.All).ToList() ?? new List<OrcanodeEvent>();
         }
 
-        public void OnGet(string id)
+        public async Task OnGetAsync(string id)
         {
-            _nodeId = id;
+            _node = _databaseContext.Orcanodes.Where(n => n.ID == id).First();
             FetchEvents(_logger);
         }
 
@@ -72,7 +75,7 @@ namespace OrcanodeMonitor.Pages
             }
             TimePeriod = timePeriod;
             EventType = eventType;
-            _nodeId = id;
+            _node = _databaseContext.Orcanodes.Where(n => n.ID == id).First();
             FetchEvents(_logger);
             return Page();
         }

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -1,0 +1,48 @@
+﻿@page "{id}"
+@model OrcanodeMonitor.Pages.SpectralDensityModel
+@{
+    ViewData["Title"] = "Spectral Density";
+}
+
+<div class="text-center">
+    <h1 class="display-4">Spectral Density</h1>
+
+    <!-- Include Chart.js from CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+    <!-- Canvas for Chart.js -->
+    <canvas id="frequencyChart" width="400" height="200"></canvas>
+    <script>
+        var ctx = document.getElementById('frequencyChart').getContext('2d');
+        var myBarChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: @Html.Raw(Json.Serialize(Model.Labels)),
+                datasets: [{
+                    label: 'Last Sample Spectral Density',
+                    data: @Html.Raw(Json.Serialize(Model.Data)),
+                    backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                    borderColor: 'rgba(75, 192, 192, 1)',
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                scales: {
+                    x: {
+                        title: {
+                            display: true,
+                            text: 'Frequency'
+                        }
+                    },
+                    y: {
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: 'Amplitude'
+                        }
+                    }
+                }
+            }
+        });
+    </script>
+</div>

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Orcanode Monitor contributors
+// SPDX-License-Identifier: MIT
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using OrcanodeMonitor.Core;
+using OrcanodeMonitor.Data;
+using OrcanodeMonitor.Models;
+using static OrcanodeMonitor.Core.Fetcher;
+
+namespace OrcanodeMonitor.Pages
+{
+    public class SpectralDensityModel : PageModel
+    {
+        private readonly OrcanodeMonitorContext _databaseContext;
+        private readonly ILogger<NodeEventsModel> _logger;
+        private string _nodeId;
+        public string Id => _nodeId;
+        private List<string> _labels;
+        private List<int> _data;
+        public List<string> Labels => _labels;
+        public List<int> Data => _data;
+
+        public SpectralDensityModel(OrcanodeMonitorContext context, ILogger<NodeEventsModel> logger)
+        {
+            _databaseContext = context;
+            _logger = logger;
+            _nodeId = string.Empty;
+        }
+
+        private async Task UpdateFrequencyDataAsync()
+        {
+            _labels = new List<string> { };
+            _data = new List<int> { };
+            Orcanode node = _databaseContext.Orcanodes.Where(n => n.ID == _nodeId).First();
+            TimestampResult? result = await GetLatestS3TimestampAsync(node, false, _logger);
+            if (result != null)
+            {
+                FrequencyInfo? frequencyInfo = await Fetcher.GetLatestAudioSampleAsync(node, result.UnixTimestampString, false, _logger);
+                if (frequencyInfo != null)
+                {
+                    const int MaxFrequency = 23000;
+                    const int PointCount = 1000;
+
+                    // Compute the logarithmic base needed to get PointCount points.
+                    double b = Math.Pow(MaxFrequency, 1.0 / PointCount);
+                    double logb = Math.Log(b);
+
+                    double maxAmplitude = frequencyInfo.FrequencyAmplitudes.Values.Max();
+                    var sums = new double[PointCount];
+                    var count = new int[PointCount];
+
+                    foreach (var pair in frequencyInfo.FrequencyAmplitudes)
+                    {
+                        double frequency = pair.Key;
+                        double amplitude = pair.Value;
+                        int bucket = (frequency < 1) ? 0 : (int)(Math.Log(frequency) / logb);
+                        count[bucket]++;
+                        sums[bucket] += amplitude;
+                    }
+
+                    // Fill in graph points.
+                    for (int i = 0; i < PointCount; i++)
+                    {
+                        if (count[i] > 0)
+                        {
+                            int frequency = (int)Math.Pow(b, i);
+                            int amplitude = (int)(sums[i] / count[i]);
+                            _labels.Add(frequency.ToString());
+                            _data.Add(amplitude);
+                        }
+                    }
+                }
+            }
+        }
+
+        public async Task OnGetAsync(string id)
+        {
+            _nodeId = id;
+            await UpdateFrequencyDataAsync();
+        }
+    }
+}

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -12,7 +12,7 @@ namespace OrcanodeMonitor.Pages
     public class SpectralDensityModel : PageModel
     {
         private readonly OrcanodeMonitorContext _databaseContext;
-        private readonly ILogger<NodeEventsModel> _logger;
+        private readonly ILogger<SpectralDensityModel> _logger;
         private string _nodeId;
         public string Id => _nodeId;
         private List<string> _labels;
@@ -20,7 +20,7 @@ namespace OrcanodeMonitor.Pages
         public List<string> Labels => _labels;
         public List<int> Data => _data;
 
-        public SpectralDensityModel(OrcanodeMonitorContext context, ILogger<NodeEventsModel> logger)
+        public SpectralDensityModel(OrcanodeMonitorContext context, ILogger<SpectralDensityModel> logger)
         {
             _databaseContext = context;
             _logger = logger;
@@ -31,7 +31,11 @@ namespace OrcanodeMonitor.Pages
         {
             _labels = new List<string> { };
             _data = new List<int> { };
-            Orcanode node = _databaseContext.Orcanodes.Where(n => n.ID == _nodeId).First();
+            Orcanode? node = _databaseContext.Orcanodes.Where(n => n.ID == _nodeId).FirstOrDefault();
+            if (node == null)
+            {
+                return;
+            }
             TimestampResult? result = await GetLatestS3TimestampAsync(node, false, _logger);
             if (result != null)
             {

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -9,6 +9,10 @@ using static OrcanodeMonitor.Core.Fetcher;
 
 namespace OrcanodeMonitor.Pages
 {
+    /// <summary>
+    /// Razor Page model for spectral density visualization.
+    /// Handles retrieval and processing of frequency data for display.
+    /// </summary>
     public class SpectralDensityModel : PageModel
     {
         private readonly OrcanodeMonitorContext _databaseContext;

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -34,6 +34,7 @@ namespace OrcanodeMonitor.Pages
             Orcanode? node = _databaseContext.Orcanodes.Where(n => n.ID == _nodeId).FirstOrDefault();
             if (node == null)
             {
+                _logger.LogWarning("Node not found with ID: {NodeId}", _nodeId);
                 return;
             }
             TimestampResult? result = await GetLatestS3TimestampAsync(node, false, _logger);

--- a/Test/UnintelligibilityTests.cs
+++ b/Test/UnintelligibilityTests.cs
@@ -24,7 +24,8 @@ namespace Test
             try
             {
                 OrcanodeOnlineStatus previousStatus = oldStatus ?? expected_status;
-                OrcanodeOnlineStatus status = await FfmpegCoreAnalyzer.AnalyzeFileAsync(filePath, previousStatus);
+                FrequencyInfo frequencyInfo = await FfmpegCoreAnalyzer.AnalyzeFileAsync(filePath, previousStatus);
+                OrcanodeOnlineStatus status = frequencyInfo.Status;
                 Assert.IsTrue(status == expected_status);
             }
             catch (Exception ex)


### PR DESCRIPTION
Add a separate page for spectral density (addresses part of #217)

Let event filters be in Javascript and not require post (Fixes #185)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new Razor page for displaying spectral density data with Chart.js integration.
	- Added dynamic filtering options for event types and time ranges on the Node Events page.
	- Enhanced frequency analysis with the new `FrequencyInfo` class for better data encapsulation.

- **Improvements**
	- Restructured methods for S3 timestamp retrieval and audio sample analysis for improved clarity and maintainability.
	- Updated event handling logic in the Node Events model for better readability and structure.
	- Enhanced user interactivity on the Node Events page with client-side filtering.

- **Bug Fixes**
	- Improved error handling for data retrieval processes to ensure graceful degradation.
	- Enhanced logging for HTTP response errors related to S3 resource access.

- **Documentation**
	- Updated page titles and added relevant properties to enhance user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->