### PR TITLE
Add silent as an S3 stream status

### DIFF
--- a/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
+++ b/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
@@ -88,14 +88,14 @@ namespace OrcanodeMonitor.Core
             if (max < MinNoiseAmplitude)
             {
                 // File contains mostly silence across all frequencies.
-                frequencyInfo.Status = OrcanodeOnlineStatus.Unintelligible;
+                frequencyInfo.Status = OrcanodeOnlineStatus.Silent;
                 return frequencyInfo;
             }
 
-            if ((max <= MaxSilenceAmplitude) && (oldStatus == OrcanodeOnlineStatus.Unintelligible))
+            if ((max <= MaxSilenceAmplitude) && (oldStatus == OrcanodeOnlineStatus.Silent))
             {
-                // In between the min and max unintelligibility range, so keep previous status.
-                frequencyInfo.Status = OrcanodeOnlineStatus.Unintelligible;
+                // In between the min and max silence range, so keep previous status.
+                frequencyInfo.Status = oldStatus;
                 return frequencyInfo;
             }
 

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -20,6 +20,7 @@ namespace OrcanodeMonitor.Models
         Hidden,
         Unauthorized,
         NoView,
+        Silent,
     }
     public enum OrcanodeUpgradeStatus
     {

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -154,6 +154,9 @@
             <b>S3 Stream Online</b>: Audio stream is working normally.
         </li>
         <li>
+            <b>S3 Stream Silent</b>: Audio stream contains silence.
+        </li>
+        <li>
             <b>S3 Stream Unauthorized</b>: Access denied when trying to check the audio stream.
         </li>
         <li>

--- a/Test/UnintelligibilityTests.cs
+++ b/Test/UnintelligibilityTests.cs
@@ -38,11 +38,16 @@ namespace Test
         }
 
         [TestMethod]
+        public async Task TestSilentSample()
+        {
+            await TestSampleAsync("unintelligible\\live1791.ts", OrcanodeOnlineStatus.Silent);
+        }
+
+        [TestMethod]
         public async Task TestUnintelligibleSample()
         {
             await TestSampleAsync("unintelligible\\live4869.ts", OrcanodeOnlineStatus.Unintelligible);
             await TestSampleAsync("unintelligible\\live1816b.ts", OrcanodeOnlineStatus.Unintelligible);
-            await TestSampleAsync("unintelligible\\live1791.ts", OrcanodeOnlineStatus.Unintelligible);
             await TestSampleAsync("unintelligible\\live1815.ts", OrcanodeOnlineStatus.Unintelligible);
             await TestSampleAsync("unintelligible\\live1816.ts", OrcanodeOnlineStatus.Unintelligible);
         }
@@ -62,11 +67,11 @@ namespace Test
         public async Task TestHysteresisBehavior()
         {
             // Bush Point file from arond 5pm 11/18/2024 is relatively quiet (max amplitude 17.46).
-            // Test state retention when transitioning from Online to borderline Unintelligible.
+            // Test state retention when transitioning from Online to borderline Silent.
             await TestSampleAsync("normal/live6079.ts", OrcanodeOnlineStatus.Online, OrcanodeOnlineStatus.Online);
 
-            // Test state retention when transitioning from Unintelligible to borderline Online.
-            await TestSampleAsync("normal/live6079.ts", OrcanodeOnlineStatus.Unintelligible, OrcanodeOnlineStatus.Unintelligible);
+            // Test state retention when transitioning from Silent to borderline Online.
+            await TestSampleAsync("normal/live6079.ts", OrcanodeOnlineStatus.Silent, OrcanodeOnlineStatus.Silent);
 
             // Test clear state changes (should override hysteresis).
             await TestSampleAsync("unintelligible/live4869.ts", OrcanodeOnlineStatus.Unintelligible, OrcanodeOnlineStatus.Online);


### PR DESCRIPTION
Fixes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `TimestampResult` class for better timestamp handling.
	- Added a `FrequencyInfo` class to encapsulate frequency data and online status.
	- New Razor page for displaying spectral density charts.
	- Dynamic title and navigation enhancements on the Node Events page.
	- Added a description for "S3 Stream Silent" in the dashboard legend.

- **Bug Fixes**
	- Improved error handling and response processing for timestamp and audio sample retrieval.

- **Documentation**
	- Updated comments in tests to reflect changes in expected states.

- **Tests**
	- Added a dedicated test for silent audio samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->