### PR TITLE
Allow getting spectral density for a specific hydrophone stream event

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -22,6 +22,7 @@ using System.Threading.Channels;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.CodeAnalysis.Elfie.Diagnostics;
 
 namespace OrcanodeMonitor.Core
 {
@@ -870,9 +871,9 @@ namespace OrcanodeMonitor.Core
             }
         }
 
-        public static void AddOrcanodeEvent(OrcanodeMonitorContext context, Orcanode node, string type, string value)
+        public static void AddOrcanodeEvent(OrcanodeMonitorContext context, Orcanode node, string type, string value, string? url = null)
         {
-            var orcanodeEvent = new OrcanodeEvent(node, type, value, DateTime.UtcNow);
+            var orcanodeEvent = new OrcanodeEvent(node, type, value, DateTime.UtcNow, url);
             context.OrcanodeEvents.Add(orcanodeEvent);
         }
 
@@ -894,16 +895,14 @@ namespace OrcanodeMonitor.Core
             AddOrcanodeEvent(context, node, OrcanodeEventTypes.SDCardSize, value);
         }
 
-        private static void AddHydrophoneStreamStatusEvent(OrcanodeMonitorContext context, Orcanode node)
+        private static void AddHydrophoneStreamStatusEvent(OrcanodeMonitorContext context, Orcanode node, string? url)
         {
             string value = node.OrcasoundOnlineStatusString;
-            AddOrcanodeEvent(context, node, OrcanodeEventTypes.HydrophoneStream, value);
+            AddOrcanodeEvent(context, node, OrcanodeEventTypes.HydrophoneStream, value, url);
         }
 
         public async static Task<FrequencyInfo?> GetLatestAudioSampleAsync(Orcanode node, string unixTimestampString, bool updateNode, ILogger logger)
         {
-            OrcanodeOnlineStatus oldStatus = node.S3StreamStatus;
-
             string url = "https://" + node.S3Bucket + ".s3.amazonaws.com/" + node.S3NodeName + "/hls/" + unixTimestampString + "/live.m3u8";
             using HttpResponseMessage response = await _httpClient.GetAsync(url);
             if (!response.IsSuccessStatusCode)
@@ -947,10 +946,18 @@ namespace OrcanodeMonitor.Core
             lineNumber = (lineNumber > 3) ? lineNumber - 3 : lineNumber - 1;
             string lastLine = lines[lineNumber];
             Uri newUri = new Uri(baseUri, lastLine);
+            return await GetExactAudioSampleAsync(node, newUri, logger);
+        }
+
+        public async static Task<FrequencyInfo?> GetExactAudioSampleAsync(Orcanode node, Uri uri, ILogger logger)
+        {
+            OrcanodeOnlineStatus oldStatus = node.S3StreamStatus;
+
             try
             {
-                using Stream stream = await _httpClient.GetStreamAsync(newUri);
+                using Stream stream = await _httpClient.GetStreamAsync(uri);
                 FrequencyInfo frequencyInfo = await FfmpegCoreAnalyzer.AnalyzeAudioStreamAsync(stream, oldStatus);
+                frequencyInfo.Url = uri.AbsoluteUri;
                 return frequencyInfo;
             }
             catch (Exception ex)
@@ -984,7 +991,7 @@ namespace OrcanodeMonitor.Core
             OrcanodeOnlineStatus newStatus = node.S3StreamStatus;
             if (newStatus != oldStatus)
             {
-                AddHydrophoneStreamStatusEvent(context, node);
+                AddHydrophoneStreamStatusEvent(context, node, frequencyInfo?.Url);
             }
         }
 

--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -13,16 +13,8 @@ using Microsoft.EntityFrameworkCore;
 using OrcanodeMonitor.Data;
 using Microsoft.IdentityModel.Tokens;
 using Mono.TextTemplating;
-using Azure.Core;
-using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using OrcanodeMonitor.Api;
-using Newtonsoft.Json.Linq;
-using System.Threading.Channels;
-using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Diagnostics;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
 
 namespace OrcanodeMonitor.Core
 {
@@ -957,7 +949,7 @@ namespace OrcanodeMonitor.Core
             {
                 using Stream stream = await _httpClient.GetStreamAsync(uri);
                 FrequencyInfo frequencyInfo = await FfmpegCoreAnalyzer.AnalyzeAudioStreamAsync(stream, oldStatus);
-                frequencyInfo.Url = uri.AbsoluteUri;
+                frequencyInfo.AudioSampleUrl = uri.AbsoluteUri;
                 return frequencyInfo;
             }
             catch (Exception ex)
@@ -991,7 +983,7 @@ namespace OrcanodeMonitor.Core
             OrcanodeOnlineStatus newStatus = node.S3StreamStatus;
             if (newStatus != oldStatus)
             {
-                AddHydrophoneStreamStatusEvent(context, node, frequencyInfo?.Url);
+                AddHydrophoneStreamStatusEvent(context, node, frequencyInfo?.AudioSampleUrl);
             }
         }
 

--- a/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
+++ b/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
@@ -112,7 +112,12 @@ namespace OrcanodeMonitor.Core
 
         public Dictionary<double, double> FrequencyMagnitudes { get; }
         public OrcanodeOnlineStatus Status { get; }
-        public string Url { get; set; } = string.Empty;
+
+        /// <summary>
+        /// URL at which the original audio sample can be found.
+        /// </summary>
+        public string AudioSampleUrl { get; set; } = string.Empty;
+
         public double MaxMagnitude => FrequencyMagnitudes.Values.Max();
 
         // Microphone audio hum typically falls within the 50 Hz or 60 Hz

--- a/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
+++ b/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
@@ -112,6 +112,7 @@ namespace OrcanodeMonitor.Core
 
         public Dictionary<double, double> FrequencyMagnitudes { get; }
         public OrcanodeOnlineStatus Status { get; }
+        public string Url { get; set; } = string.Empty;
         public double MaxMagnitude => FrequencyMagnitudes.Values.Max();
 
         // Microphone audio hum typically falls within the 50 Hz or 60 Hz

--- a/OrcanodeMonitor/Core/MezmoFetcher.cs
+++ b/OrcanodeMonitor/Core/MezmoFetcher.cs
@@ -344,7 +344,7 @@ namespace OrcanodeMonitor.Core
         private static void AddMezmoStatusEvent(OrcanodeMonitorContext context, Orcanode node)
         {
             string value = node.MezmoStatus.ToString();
-            Fetcher.AddOrcanodeEvent(context, node, OrcanodeEventTypes.MezmoLogging, value);
+            Fetcher.AddOrcanodeEvent(context, node, OrcanodeEventTypes.MezmoLogging, value, string.Empty);
         }
     }
 }

--- a/OrcanodeMonitor/Models/OrcanodeEvent.cs
+++ b/OrcanodeMonitor/Models/OrcanodeEvent.cs
@@ -78,9 +78,10 @@ namespace OrcanodeMonitor.Models
             ID = string.Empty;
             DateTimeUtc = DateTime.UtcNow;
             Year = DateTimeUtc.Year;
+            Url = string.Empty;
         }
 
-        public OrcanodeEvent(Orcanode node, string type, string value, DateTime timestamp)
+        public OrcanodeEvent(Orcanode node, string type, string value, DateTime timestamp, string? url)
         {
             Slug = node.OrcasoundSlug;
             Type = type;
@@ -89,6 +90,7 @@ namespace OrcanodeMonitor.Models
             OrcanodeId = node.ID;
             Year = timestamp.Year;
             ID = Guid.NewGuid().ToString();
+            Url = url ?? string.Empty;
         }
 
         #region persisted
@@ -117,6 +119,8 @@ namespace OrcanodeMonitor.Models
         public DateTime DateTimeUtc { get; set; }
 
         public int Year { get; set; }
+
+        public string Url { get; set; }
 
         #endregion persisted
 

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml
@@ -48,7 +48,8 @@
         <thead>
             <tr>
                 <th>Timestamp (Pacific)</th>
-                <th>Event</th>
+                <th align="left">Event</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -62,7 +63,21 @@
             {
                 <tr class="@Model.GetEventClasses(item)">
                     <td>@item.DateTimeLocal.ToString("g")</td>
-                    <td align="left">@item.Description</td>
+                    <td align="left">
+                        @if (!string.IsNullOrEmpty(item.Url))
+                        {
+                            <a href="@item.Url">@item.Description</a>
+                        }
+                        else
+                        {
+                            <span>@item.Description</span>
+                        }
+                    </td>
+                    <td>
+                        <button onclick="location.href='@Url.Page("/SpectralDensity", new { id = item.ID })'" class="btn selected" style="@Model.GetEventButtonStyle(item)">
+                            View Spectral Density
+                        </button>
+                    </td>
                 </tr>
             }
         </tbody>

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -79,5 +79,14 @@ namespace OrcanodeMonitor.Pages
             string classes = GetTypeClass(item) + " " + GetTimeRangeClass(item);
             return classes;
         }
+
+        public string GetEventButtonStyle(OrcanodeEvent item)
+        {
+            if ((item.Type == OrcanodeEventTypes.HydrophoneStream) && (item.Url != null))
+            {
+                return "display: inline-block;";
+            }
+            return "display: none;";
+        }
     }
 }

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Orcanode Monitor contributors
 // SPDX-License-Identifier: MIT
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Logging;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
@@ -58,7 +56,7 @@ namespace OrcanodeMonitor.Pages
             {
                 double frequency = pair.Key;
                 double magnitude = pair.Value;
-                int bucket = (frequency < 1) ? 0 : (int)(Math.Log(frequency) / logb);
+                int bucket = (frequency < 1) ? 0 : Math.Min(PointCount - 1, (int)(Math.Log(frequency) / logb));
                 if (maxBucketMagnitude[bucket] < magnitude)
                 {
                     maxBucketMagnitude[bucket] = magnitude;

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -17,8 +17,10 @@ namespace OrcanodeMonitor.Pages
     {
         private readonly OrcanodeMonitorContext _databaseContext;
         private readonly ILogger<SpectralDensityModel> _logger;
+        private string _eventId;
         private string _nodeId;
-        public string Id => _nodeId;
+        public string NodeId => _nodeId;
+        public string EventId => _eventId;
         public string NodeName { get; private set; }
         private List<string> _labels;
         private List<double> _maxBucketMagnitude;
@@ -34,10 +36,57 @@ namespace OrcanodeMonitor.Pages
             _databaseContext = context;
             _logger = logger;
             _nodeId = string.Empty;
+            _eventId = string.Empty;
             NodeName = "Unknown";
+            Status = string.Empty;
+            _labels = new List<string>();
+            _maxBucketMagnitude = new List<double>();
         }
 
-        private async Task UpdateFrequencyDataAsync()
+        private void UpdateFrequencyInfo(FrequencyInfo frequencyInfo)
+        {
+            const int MaxFrequency = 24000;
+            const int PointCount = 1000;
+
+            // Compute the logarithmic base needed to get PointCount points.
+            double b = Math.Pow(MaxFrequency, 1.0 / PointCount);
+            double logb = Math.Log(b);
+
+            double maxMagnitude = frequencyInfo.MaxMagnitude;
+            var maxBucketMagnitude = new double[PointCount];
+            var maxBucketFrequency = new int[PointCount];
+
+            foreach (var pair in frequencyInfo.FrequencyMagnitudes)
+            {
+                double frequency = pair.Key;
+                double magnitude = pair.Value;
+                int bucket = (frequency < 1) ? 0 : (int)(Math.Log(frequency) / logb);
+                if (maxBucketMagnitude[bucket] < magnitude)
+                {
+                    maxBucketMagnitude[bucket] = magnitude;
+                    maxBucketFrequency[bucket] = (int)Math.Round(frequency);
+                }
+            }
+
+            // Fill in graph points.
+            for (int i = 0; i < PointCount; i++)
+            {
+                if (maxBucketMagnitude[i] > 0)
+                {
+                    _labels.Add(maxBucketFrequency[i].ToString());
+                    _maxBucketMagnitude.Add(maxBucketMagnitude[i]);
+                }
+            }
+
+            double maxNonHumMagnitude = frequencyInfo.GetMaxNonHumMagnitude();
+            MaxMagnitude = (int)Math.Round(maxMagnitude);
+            MaxNonHumMagnitude = (int)Math.Round(maxNonHumMagnitude);
+            SignalRatio = (int)Math.Round(100 * maxNonHumMagnitude / maxMagnitude);
+            Status = Orcanode.GetStatusString(frequencyInfo.Status);
+        }
+
+#if false
+        private async Task UpdateNodeFrequencyDataAsync()
         {
             _labels = new List<string> { };
             _maxBucketMagnitude = new List<double> { };
@@ -54,52 +103,46 @@ namespace OrcanodeMonitor.Pages
                 FrequencyInfo? frequencyInfo = await Fetcher.GetLatestAudioSampleAsync(node, result.UnixTimestampString, false, _logger);
                 if (frequencyInfo != null)
                 {
-                    const int MaxFrequency = 24000;
-                    const int PointCount = 1000;
-
-                    // Compute the logarithmic base needed to get PointCount points.
-                    double b = Math.Pow(MaxFrequency, 1.0 / PointCount);
-                    double logb = Math.Log(b);
-
-                    double maxMagnitude = frequencyInfo.MaxMagnitude;
-                    var maxBucketMagnitude = new double[PointCount];
-                    var maxBucketFrequency = new int[PointCount];
-
-                    foreach (var pair in frequencyInfo.FrequencyMagnitudes)
-                    {
-                        double frequency = pair.Key;
-                        double magnitude = pair.Value;
-                        int bucket = (frequency < 1) ? 0 : (int)(Math.Log(frequency) / logb);
-                        if (maxBucketMagnitude[bucket] < magnitude)
-                        {
-                            maxBucketMagnitude[bucket] = magnitude;
-                            maxBucketFrequency[bucket] = (int)Math.Round(frequency);
-                        }
-                    }
-
-                    // Fill in graph points.
-                    for (int i = 0; i < PointCount; i++)
-                    {
-                        if (maxBucketMagnitude[i] > 0)
-                        {
-                            _labels.Add(maxBucketFrequency[i].ToString());
-                            _maxBucketMagnitude.Add(maxBucketMagnitude[i]);
-                        }
-                    }
-
-                    double maxNonHumMagnitude = frequencyInfo.GetMaxNonHumMagnitude();
-                    MaxMagnitude = (int)Math.Round(maxMagnitude);
-                    MaxNonHumMagnitude = (int)Math.Round(maxNonHumMagnitude);
-                    SignalRatio = (int)Math.Round(100 * maxNonHumMagnitude / maxMagnitude);
-                    Status = Orcanode.GetStatusString(frequencyInfo.Status);
+                    UpdateFrequencyInfo(frequencyInfo);
                 }
+            }
+        }
+#endif
+
+        private async Task UpdateEventFrequencyDataAsync()
+        {
+            _labels = new List<string> { };
+            _maxBucketMagnitude = new List<double> { };
+            OrcanodeEvent? e = _databaseContext.OrcanodeEvents.Where(e => e.ID == _eventId).FirstOrDefault();
+            if (e == null)
+            {
+                _logger.LogWarning("Node not found with ID: {EventId}", _eventId);
+                return;
+            }
+            Orcanode? node = e.Orcanode;
+            if (node == null)
+            {
+                _logger.LogWarning("Node not found with ID: {NodeId}", _nodeId);
+                return;
+            }
+            NodeName = node.DisplayName;
+            Uri? uri;
+            if (!Uri.TryCreate(e.Url, UriKind.Absolute, out uri) || (uri == null))
+            {
+                _logger.LogWarning("URI not found with event ID: {EventID}", _eventId);
+                return;
+            }
+            FrequencyInfo? frequencyInfo = await Fetcher.GetExactAudioSampleAsync(node, uri, _logger);
+            if (frequencyInfo != null)
+            {
+                UpdateFrequencyInfo(frequencyInfo);
             }
         }
 
         public async Task OnGetAsync(string id)
         {
-            _nodeId = id;
-            await UpdateFrequencyDataAsync();
+            _eventId = id;
+            await UpdateEventFrequencyDataAsync();
         }
     }
 }

--- a/TransferData/Program.cs
+++ b/TransferData/Program.cs
@@ -115,7 +115,7 @@ namespace OrcanodeMonitor
                 {
                     continue;
                 }
-                OrcanodeEvent toEvent = new OrcanodeEvent(toNode, fromItem.Type, fromItem.Value, fromItem.DateTimeUtc);
+                OrcanodeEvent toEvent = new OrcanodeEvent(toNode, fromItem.Type, fromItem.Value, fromItem.DateTimeUtc, fromItem.Url);
                 toContext.OrcanodeEvents.Add(toEvent);
             }
             await toContext.SaveChangesAsync();


### PR DESCRIPTION
Fixes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for associating URLs with events in the OrcanodeMonitor.
	- Introduced a button for viewing spectral density related to events.
	- Enhanced event display logic to conditionally show buttons based on event properties.

- **Bug Fixes**
	- Improved handling of audio sample retrieval with more explicit URI types.

- **Documentation**
	- Updated HTML structure for event descriptions and button placements.

- **Chores**
	- Refined data transfer logic to include URL property during event transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->