### PR TITLE
Don't display Spectral Density button when the URL is an empty string

### DIFF
--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
-using static OrcanodeMonitor.Core.Fetcher;
 
 namespace OrcanodeMonitor.Pages
 {
@@ -82,7 +81,7 @@ namespace OrcanodeMonitor.Pages
 
         public string GetEventButtonStyle(OrcanodeEvent item)
         {
-            if ((item.Type == OrcanodeEventTypes.HydrophoneStream) && (item.Url != null))
+            if ((item.Type == OrcanodeEventTypes.HydrophoneStream) && !string.IsNullOrEmpty(item.Url))
             {
                 return "display: inline-block;";
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved event button display logic for hydrophone stream events by ensuring the URL is not only present but also non-empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->