### PR TITLE
Add Play button to spectral density page

### DIFF
--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -4,6 +4,7 @@
     ViewData["Title"] = "Spectral Density";
 }
 
+<script src="https://github.com/xqq/mpegts.js/releases/download/v1.8.0/mpegts.js"></script>
 <div class="text-center">
     <h1 class="display-4">Spectral Density of Audio From @Model.NodeName</h1>
 
@@ -76,6 +77,54 @@
         Max magnitude outside hum range (50-60Hz): @Model.MaxNonHumMagnitude<br />
         Signal ratio: @Model.SignalRatio%<br />
         Status: @Model.Status<br />
+        <!-- Audio Button and Element -->
+        <button id="playButton" onclick="playAudio('@Model.AudioUrl')">Play</button>
+        <button id="stopButton" onclick="stopAudio()" style="display: none;">Stop</button>
+        <audio id="audioElement" controls style="display:none;"></audio>
+        <script>
+            var player;
+
+            function playAudio(url) {
+                var audioElement = document.getElementById('audioElement');
+                var playButton = document.getElementById('playButton');
+                var stopButton = document.getElementById('stopButton');
+
+                if (mpegts.getFeatureList().mseLivePlayback) {
+                    console.log("mpegts.js is supported, playing " + url);
+                    player = mpegts.createPlayer({
+                        type: 'mse',
+                        isLive: true,
+                        url: url });
+                    player.attachMediaElement(audioElement);
+                    player.load();
+                    player.play();
+
+                    // Toggle buttons
+                    playButton.style.display = 'none';
+                    stopButton.style.display = 'inline-block';
+                } else {
+                    console.log("mpegts.js is not supported on this browser.");
+                }
+            }
+            function stopAudio() {
+                if (player) {
+                    var playButton = document.getElementById('playButton');
+                    var stopButton = document.getElementById('stopButton');
+
+                    player.unload();
+                    player.detachMediaElement();
+                    player.destroy();
+                    player = null;
+                    console.log("Audio stopped and player cleaned up.");
+
+                    // Toggle buttons
+                    playButton.style.display = 'inline-block';
+                    stopButton.style.display = 'none';
+                } else {
+                    console.log("No audio is currently playing.");
+                }
+            }
+        </script>
         <p></p>
     </div>
 </div>

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -24,6 +24,7 @@ namespace OrcanodeMonitor.Pages
         private List<double> _maxBucketMagnitude;
         public List<string> Labels => _labels;
         public List<double> MaxBucketMagnitude => _maxBucketMagnitude;
+        public string AudioUrl => _event?.Url ?? "Unknown";
         public int MaxMagnitude { get; private set; }
         public int MaxNonHumMagnitude { get; private set; }
         public int SignalRatio { get; private set; }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added audio playback functionality to the Spectral Density page
	- Introduced play and stop buttons for audio control
	- Implemented ability to stream audio using MPEG transport streams

- **Improvements**
	- Added audio URL retrieval for events
	- Enhanced page interactivity with audio playback controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->