### PR TITLE
Add timestamp on spectral density page

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -941,6 +941,11 @@ namespace OrcanodeMonitor.Core
             return await GetExactAudioSampleAsync(node, newUri, logger);
         }
 
+        /// <summary>
+        /// Retrieves the last modified date of a resource via HTTP HEAD request.
+        /// </summary>
+        /// <param name="uri">The URI of the resource to check.</param>
+        /// <returns>The last modified date in UTC, or null if not available.</returns>
         public async static Task<DateTime?> GetLastModifiedAsync(Uri uri)
         {
             using var headRequest = new HttpRequestMessage(HttpMethod.Head, uri);

--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -941,6 +941,14 @@ namespace OrcanodeMonitor.Core
             return await GetExactAudioSampleAsync(node, newUri, logger);
         }
 
+        public async static Task<DateTime?> GetLastModifiedAsync(Uri uri)
+        {
+            using var headRequest = new HttpRequestMessage(HttpMethod.Head, uri);
+            using var headResponse = await _httpClient.SendAsync(headRequest);
+            DateTime? lastModified = headResponse.Content.Headers.LastModified?.UtcDateTime;
+            return lastModified;
+        }
+
         public async static Task<FrequencyInfo?> GetExactAudioSampleAsync(Orcanode node, Uri uri, ILogger logger)
         {
             OrcanodeOnlineStatus oldStatus = node.S3StreamStatus;

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -7,6 +7,7 @@
 <script src="https://github.com/xqq/mpegts.js/releases/download/v1.8.0/mpegts.js"></script>
 <div class="text-center">
     <h1 class="display-4">Spectral Density of Audio From @Model.NodeName</h1>
+    As of: @Model.LastModified<br />
 
     <!-- Include Chart.js from CDN -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1"></script>
@@ -21,7 +22,7 @@
                 labels: @Html.Raw(Json.Serialize(Model.Labels)),
                 datasets: [
                     {
-                        label: 'Last Sample',
+                        label: 'Audio Sample',
                         data: @Html.Raw(Json.Serialize(Model.MaxBucketMagnitude)),
                         backgroundColor: 'rgba(75, 192, 192, 0.2)',
                         borderColor: 'rgba(75, 192, 192, 1)',

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -31,6 +31,7 @@ namespace OrcanodeMonitor.Pages
         public string Status { get; private set; }
         public double MaxSilenceMagnitude => FrequencyInfo.MaxSilenceMagnitude;
         public double MinNoiseMagnitude => FrequencyInfo.MinNoiseMagnitude;
+        public string LastModified { get; private set; }
 
         public SpectralDensityModel(OrcanodeMonitorContext context, ILogger<SpectralDensityModel> logger)
         {
@@ -113,6 +114,10 @@ namespace OrcanodeMonitor.Pages
                 _logger.LogWarning("URI not found with event ID: {EventID}", _id);
                 return;
             }
+
+            DateTime? lastModified = await Fetcher.GetLastModifiedAsync(uri);
+            LastModified = lastModified?.ToLocalTime().ToString() ?? "Unknown";
+
             FrequencyInfo? frequencyInfo = await Fetcher.GetExactAudioSampleAsync(_node, uri, _logger);
             if (frequencyInfo != null)
             {


### PR DESCRIPTION
Add timestamp on spectral density page
Change label of "Last Sample" (fixes #246)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to retrieve the last modified date of resources.
	- Enhanced Spectral Density page to display the last modified timestamp of audio data.

- **Bug Fixes**
	- Updated dataset label for clarity in the Spectral Density chart.

These changes improve resource tracking and provide more informative metadata for users regarding audio sample timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->