### PR TITLE
Rename AMPLITUDE environment variables to MAGNITUDE 

### DIFF
--- a/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
+++ b/OrcanodeMonitor/Core/FfmpegCoreAnalyzer.cs
@@ -79,7 +79,7 @@ namespace OrcanodeMonitor.Core
         {
             get
             {
-                string? maxSilenceMagnitudeString = Environment.GetEnvironmentVariable("ORCASOUND_MAX_SILENCE_AMPLITUDE");
+                string? maxSilenceMagnitudeString = Environment.GetEnvironmentVariable("ORCASOUND_MAX_SILENCE_MAGNITUDE");
                 double maxSilenceMagnitude = double.TryParse(maxSilenceMagnitudeString, out var magnitude) ? magnitude : _defaultMaxSilenceMagnitude;
                 return maxSilenceMagnitude;
             }
@@ -91,7 +91,7 @@ namespace OrcanodeMonitor.Core
         {
             get
             {
-                string? minNoiseMagnitudeString = Environment.GetEnvironmentVariable("ORCASOUND_MIN_NOISE_AMPLITUDE");
+                string? minNoiseMagnitudeString = Environment.GetEnvironmentVariable("ORCASOUND_MIN_NOISE_MAGNITUDE");
                 double minNoiseMagnitude = double.TryParse(minNoiseMagnitudeString, out var magnitude) ? magnitude : _defaultMinNoiseMagnitude;
                 return minNoiseMagnitude;
             }

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -115,14 +115,14 @@ The following state will be stored per orcanode:
 
 **ORCASOUND_MIN_INTELLIGIBLE_SIGNAL_PERCENT**: The minimum percentage of total magnitude across all frequencies outside the hum range vs magnitude in hum range (multiples of 60 Hz), needed to determine that an audio stream is intelligible. Default: 150
 
-**ORCASOUND_MAX_SILENCE_MAGNITUDE**: The maximum magnitude at which an stream stream might still be considered unintelligible due to silence. Default: 20
+**ORCASOUND_MAX_SILENCE_MAGNITUDE**: The maximum magnitude at which a stream stream might still be considered unintelligible due to silence. Default: 20
 
-**ORCASOUND_MIN_NOISE_MAGNITUDE**: The minimum magnitude at which an stream stream might still be considered intelligible. Default: 15
+**ORCASOUND_MIN_NOISE_MAGNITUDE**: The minimum magnitude at which a stream stream might still be considered intelligible. Default: 15
 
 These magnitude thresholds work together to implement hysteresis in the noise detection:
-- Amplitudes below ORCASOUND_MIN_NOISE_MAGNITUDE are always considered silent.
-- Amplitudes above ORCASOUND_MAX_SILENCE_MAGNITUDE are always considered noisy.
-- Amplitudes between these thresholds maintain their previous state to prevent rapid oscillation between states.
+- Magnitudes below ORCASOUND_MIN_NOISE_MAGNITUDE are always considered silent.
+- Magnitudes above ORCASOUND_MAX_SILENCE_MAGNITUDE are always considered noisy.
+- Magnitudes between these thresholds maintain their previous state to prevent rapid oscillation between states.
 
 ## Web page front end
 

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -115,13 +115,13 @@ The following state will be stored per orcanode:
 
 **ORCASOUND_MIN_INTELLIGIBLE_SIGNAL_PERCENT**: The minimum percentage of total magnitude across all frequencies outside the hum range vs magnitude in hum range (multiples of 60 Hz), needed to determine that an audio stream is intelligible. Default: 150
 
-**ORCASOUND_MAX_SILENCE_AMPLITUDE**: The maximum amplitude at which an stream stream might still be considered unintelligible due to silence. Default: 20
+**ORCASOUND_MAX_SILENCE_MAGNITUDE**: The maximum magnitude at which an stream stream might still be considered unintelligible due to silence. Default: 20
 
-**ORCASOUND_MIN_NOISE_AMPLITUDE**: The minimum amplitude at which an stream stream might still be considered intelligible. Default: 15
+**ORCASOUND_MIN_NOISE_MAGNITUDE**: The minimum magnitude at which an stream stream might still be considered intelligible. Default: 15
 
-These amplitude thresholds work together to implement hysteresis in the noise detection:
-- Amplitudes below MIN_NOISE_AMPLITUDE are always considered silent.
-- Amplitudes above MAX_SILENCE_AMPLITUDE are always considered noisy.
+These magnitude thresholds work together to implement hysteresis in the noise detection:
+- Amplitudes below ORCASOUND_MIN_NOISE_MAGNITUDE are always considered silent.
+- Amplitudes above ORCASOUND_MAX_SILENCE_MAGNITUDE are always considered noisy.
 - Amplitudes between these thresholds maintain their previous state to prevent rapid oscillation between states.
 
 ## Web page front end


### PR DESCRIPTION
Fixes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated terminology from "amplitude" to "magnitude" for audio stream detection thresholds in design documentation
	- Renamed environment variable parameters to reflect magnitude-based terminology

- **Chores**
	- Updated code to use consistent terminology for audio stream detection parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->