### PR TITLE
Use mpegts.js from a CDN

### DIFF
--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Spectral Density";
 }
 
-<script src="https://github.com/xqq/mpegts.js/releases/download/v1.8.0/mpegts.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mpegts.js@1.8.0/dist/mpegts.min.js"></script>
 <div class="text-center">
     <h1 class="display-4">Spectral Density of Audio From @Model.NodeName</h1>
     As of: @Model.LastModified<br />


### PR DESCRIPTION
Fixes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the source of the `mpegts.js` script from a GitHub release URL to a CDN link from jsDelivr.
	- No functional changes to the page or script behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->