### PR TITLE
Show channels separately in spectral density view

### DIFF
--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -13,66 +13,114 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1"></script>
 
     <!-- Canvas for Chart.js -->
-    <canvas id="frequencyChart" width="400" height="200"></canvas>
+    @for (int i = 0; i < Model.ChannelCount; i++)
+    {
+        <canvas id="frequencyChart@(i + 1)" width="400" height="200"></canvas>
+    }
     <script>
-        var ctx = document.getElementById('frequencyChart').getContext('2d');
-        var myLineChart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: @Html.Raw(Json.Serialize(Model.Labels)),
-                datasets: [
-                    @for (int i = 0; i < Model.ChannelCount; i++)
-                    {
-                   @: {
-                   @:     label: 'Channel @(i+1)',
-                   @:     data: @Html.Raw(Model.JsonChannelDatasets[i]),
-                   @:     backgroundColor: @Html.Raw(Model.GetChannelColor(@i, 0.2)),
-                   @:     borderColor: @Html.Raw(Model.GetChannelColor(@i, 1)),
-                   @:     borderWidth: 1
-                   @: },
-                    }
-                    {
-                        label: 'Max Noise Magnitude',
-                        data: [
-                            { x: @Html.Raw(Json.Serialize(Model.Labels[0])), y: @Html.Raw(Model.MaxSilenceMagnitude) },
-                            { x: @Html.Raw(Json.Serialize(Model.Labels[Model.Labels.Count - 1])), y: @Html.Raw(Model.MaxSilenceMagnitude) }
-                        ],
-                        borderColor: 'rgba(54, 162, 235, 1)',
-                        borderWidth: 2,
-                        fill: false,
-                        pointRadius: 0 // Hide points on this line
-                    },
-                    {
-                        label: 'Min Signal Magnitude',
-                        data: [
-                            { x: @Html.Raw(Json.Serialize(Model.Labels[0])), y: @Html.Raw(Model.MinNoiseMagnitude) },
-                            { x: @Html.Raw(Json.Serialize(Model.Labels[Model.Labels.Count - 1])), y: @Html.Raw(Model.MinNoiseMagnitude) }
-                        ],
-                        borderColor: 'rgba(255, 99, 132, 1)',
-                        borderWidth: 2,
-                        fill: false,
-                        pointRadius: 0 // Hide points on this line
-                    }
-                ]
-            },
-            options: {
-                scales: {
-                    x: {
-                        title: {
-                            display: true,
-                            text: 'Frequency'
+         // Client side function to initialize all charts.
+        function initializeCharts2(labels, jsonChannelDatasets)
+        {
+            var maxSilenceMagnitude = @Model.MaxSilenceMagnitude;
+            var minNoiseMagnitude = @Model.MinNoiseMagnitude;
+
+            // Channel Count = @Model.ChannelCount
+
+            // DEBUGGING...
+            var dataset = jsonChannelDatasets[0];
+            console.info('channel[0]: ' + dataset);
+
+            @for (int i = 0; i < Model.ChannelCount; i++)
+            {
+                string backgroundColor = Model.GetChannelColor(i, 0.2);
+                string borderColor = Model.GetChannelColor(i, 1);
+                string id = "frequencyChart" + (i + 1).ToString();
+
+                @: initializeChart(
+                @:     '@id',
+                @:     labels,
+                @:     jsonChannelDatasets[@i],
+                @:     maxSilenceMagnitude,
+                @:     minNoiseMagnitude,
+                @:     @i,
+                @:     '@backgroundColor',
+                @:     '@borderColor'
+                @: );
+            }
+        }
+
+        function initializeCharts()
+        {
+            var labels = @Html.Raw(Json.Serialize(Model.Labels));
+            var jsonChannelDatasets = @Html.Raw(Json.Serialize(Model.JsonChannelDatasets));
+            initializeCharts2(labels, jsonChannelDatasets);
+        }
+
+        // Client side function to initialize a chart.
+        function initializeChart(elementId, labels, jsonChannelDataset, maxSilenceMagnitude, minNoiseMagnitude, i, backgroundColor, borderColor)
+        {
+            console.info('initializeChart ' + i);
+            console.info(jsonChannelDataset);
+
+            var ctx = document.getElementById(elementId).getContext('2d');
+            var myLineChart = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [
+                        {
+                            label: 'Channel ' + (i + 1),
+                            data: jsonChannelDataset,
+                            backgroundColor: backgroundColor,
+                            borderColor: borderColor,
+                            borderWidth: 1
+                        },
+                        {
+                            label: 'Max Noise Magnitude',
+                            data: [
+                                { x: labels[0], y: maxSilenceMagnitude },
+                                { x: labels[labels.length - 1], y: maxSilenceMagnitude }
+                            ],
+                            borderColor: 'rgba(54, 162, 235, 1)',
+                            borderWidth: 2,
+                            fill: false,
+                            pointRadius: 0 // Hide points on this line
+                        },
+                        {
+                            label: 'Min Signal Magnitude',
+                            data: [
+                                { x: labels[0], y: minNoiseMagnitude },
+                                { x: labels[labels.length - 1], y: minNoiseMagnitude }
+                            ],
+                            borderColor: 'rgba(255, 99, 132, 1)',
+                            borderWidth: 2,
+                            fill: false,
+                            pointRadius: 0 // Hide points on this line
                         }
-                    },
-                    y: {
-                        beginAtZero: true,
-                        title: {
-                            display: true,
-                            text: 'Magnitude'
+                    ]
+                },
+                options: {
+                    scales: {
+                        x: {
+                            title: {
+                                display: true,
+                                text: 'Frequency'
+                            }
+                        },
+                        y: {
+                            beginAtZero: true,
+                            title: {
+                                display: true,
+                                text: 'Magnitude'
+                            }
                         }
                     }
                 }
-            }
-        });
+            });
+            return myLineChart;
+        }
+
+        document.addEventListener('DOMContentLoaded', initializeCharts);
     </script>
 
     <div>

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -26,10 +26,6 @@
 
             // Channel Count = @Model.ChannelCount
 
-            // DEBUGGING...
-            var dataset = jsonChannelDatasets[0];
-            console.info('channel[0]: ' + dataset);
-
             @for (int i = 0; i < Model.ChannelCount; i++)
             {
                 string backgroundColor = Model.GetChannelColor(i, 0.2);
@@ -52,16 +48,13 @@
         function initializeCharts()
         {
             var labels = @Html.Raw(Json.Serialize(Model.Labels));
-            var jsonChannelDatasets = @Html.Raw(Json.Serialize(Model.JsonChannelDatasets));
+            var jsonChannelDatasets = @Html.Raw(Model.JsonChannelDatasets);
             initializeCharts2(labels, jsonChannelDatasets);
         }
 
         // Client side function to initialize a chart.
         function initializeChart(elementId, labels, jsonChannelDataset, maxSilenceMagnitude, minNoiseMagnitude, i, backgroundColor, borderColor)
         {
-            console.info('initializeChart ' + i);
-            console.info(jsonChannelDataset);
-
             var ctx = document.getElementById(elementId).getContext('2d');
             var myLineChart = new Chart(ctx, {
                 type: 'line',

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
+using System.Collections.Generic;
 using System.Text.Json;
 using static OrcanodeMonitor.Core.Fetcher;
 
@@ -156,7 +157,7 @@ namespace OrcanodeMonitor.Pages
 
             // Serialise to JSON.
             JsonSummaryDataset = JsonSerializer.Serialize(summaryDataset);
-            JsonChannelDatasets = channelDatasets.Select(dataset => JsonSerializer.Serialize(dataset)).ToList();
+            JsonChannelDatasets = JsonSerializer.Serialize(channelDatasets); // channelDatasets.Select(dataset => JsonSerializer.Serialize(dataset)).ToList();
 
             MaxMagnitude = (int)Math.Round(_frequencyInfo.GetMaxMagnitude());
             MaxNonHumMagnitude = (int)Math.Round(_frequencyInfo.GetMaxNonHumMagnitude());
@@ -177,7 +178,7 @@ namespace OrcanodeMonitor.Pages
         /// Gets or sets the JSON-serialized datasets containing per-channel frequency magnitudes.
         /// Used by Chart.js for visualization when multiple channels are present.
         /// </summary>
-        public List<string> JsonChannelDatasets { get; set; }
+        public string JsonChannelDatasets { get; set; }
 
         public string GetChannelColor(int channelIndex, double alpha)
         {

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -98,15 +98,15 @@ namespace OrcanodeMonitor.Pages
 
         private double GetBucketMagnitude(string label, List<string> labels, List<double> magnitudes)
         {
-            double sum = 0;
+            double max = 0;
             for (int i = 0; i < labels.Count; i++)
             {
-                if (labels[i] == label)
+                if (labels[i] == label && magnitudes[i] > max)
                 {
-                    sum += magnitudes[i];
+                    max = magnitudes[i];
                 }
             }
-            return sum;
+            return max;
         }
 
         private void UpdateFrequencyInfo()
@@ -191,7 +191,7 @@ namespace OrcanodeMonitor.Pages
                 (54, 162, 235),   // Blue
             };
             var (r, g, b) = colors[channelIndex % colors.Length];
-            return $"'rgba({r}, {g}, {b}, {alpha})'";
+            return $"rgba({r}, {g}, {b}, {alpha})";
         }
 
         /// <summary>
@@ -229,6 +229,8 @@ namespace OrcanodeMonitor.Pages
                 {
                     _frequencyInfo = await Fetcher.GetLatestAudioSampleAsync(_node, result.UnixTimestampString, false, _logger);
                     UpdateFrequencyInfo();
+
+                    LastModified = DateTime.Now.ToLocalTime().ToString();
                 }
                 catch (Exception ex)
                 {

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -157,7 +157,7 @@ namespace OrcanodeMonitor.Pages
 
             // Serialise to JSON.
             JsonSummaryDataset = JsonSerializer.Serialize(summaryDataset);
-            JsonChannelDatasets = JsonSerializer.Serialize(channelDatasets); // channelDatasets.Select(dataset => JsonSerializer.Serialize(dataset)).ToList();
+            JsonChannelDatasets = JsonSerializer.Serialize(channelDatasets);
 
             MaxMagnitude = (int)Math.Round(_frequencyInfo.GetMaxMagnitude());
             MaxNonHumMagnitude = (int)Math.Round(_frequencyInfo.GetMaxNonHumMagnitude());

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -231,7 +231,8 @@ namespace OrcanodeMonitor.Pages
                     _frequencyInfo = await Fetcher.GetLatestAudioSampleAsync(_node, result.UnixTimestampString, false, _logger);
                     UpdateFrequencyInfo();
 
-                    LastModified = DateTime.Now.ToLocalTime().ToString();
+                    // Use local time.
+                    LastModified = DateTime.Now.ToString();
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Show max instead of sum for bucket magnitudes (fixes #269)

Show "As of" timestamp for last sample display instead of empty string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the audio spectral density display to dynamically render multiple charts for each channel.

- **Refactor**
  - Redesigned the chart initialization flow for improved modularity.
  - Optimized audio frequency processing to capture peak magnitudes more accurately and streamlined data serialization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->