### PR TITLE
Add uptime to legend

### DIFF
--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -163,6 +163,9 @@
             <b>S3 Stream Unintelligible</b>: Audio stream is being sent to S3 but it appears to be bad.
         </li>
         <li>
+            <b>Up%</b>: Percentage of time the S3 Stream has been online over the past week.
+        </li>
+        <li>
             <b>Orcasound Absent</b>: orcasound.net does not know about the node.
         </li>
         <li>

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml
@@ -121,23 +121,6 @@
         });
     </script>
 
-    <div>
-        Uptime percentage:
-        <span id="uptime-all-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("all", "pastWeek")%</span>
-        <span id="uptime-hydrophoneStream-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "pastWeek")%</span>
-        <span id="uptime-dataplicityConnection-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "pastWeek")%</span>
-        <span id="uptime-mezmoLogging-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "pastWeek")%</span>
-        <span id="uptime-all-pastMonth" class="uptime-percentage">@Model.GetUptimePercentage("all", "pastMonth")%</span>
-        <span id="uptime-hydrophoneStream-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "pastMonth")%</span>
-        <span id="uptime-dataplicityConnection-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "pastMonth")%</span>
-        <span id="uptime-mezmoLogging-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "pastMonth")%</span>
-        <span id="uptime-all-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("all", "all")%</span>
-        <span id="uptime-hydrophoneStream-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "all")%</span>
-        <span id="uptime-dataplicityConnection-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "all")%</span>
-        <span id="uptime-mezmoLogging-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "all")%</span>
-        <p></p>
-    </div>
-
     <!-- Filter Buttons for Time Range -->
     <div>
         Filter by Time Range:
@@ -157,6 +140,22 @@
         <p></p>
     </div>
 
+    <div>
+        Uptime percentage:
+        <span id="uptime-all-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("all", "pastWeek")%</span>
+        <span id="uptime-hydrophoneStream-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "pastWeek")%</span>
+        <span id="uptime-dataplicityConnection-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "pastWeek")%</span>
+        <span id="uptime-mezmoLogging-pastWeek" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "pastWeek")%</span>
+        <span id="uptime-all-pastMonth" class="uptime-percentage">@Model.GetUptimePercentage("all", "pastMonth")%</span>
+        <span id="uptime-hydrophoneStream-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "pastMonth")%</span>
+        <span id="uptime-dataplicityConnection-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "pastMonth")%</span>
+        <span id="uptime-mezmoLogging-pastMonth" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "pastMonth")%</span>
+        <span id="uptime-all-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("all", "all")%</span>
+        <span id="uptime-hydrophoneStream-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("hydrophoneStream", "all")%</span>
+        <span id="uptime-dataplicityConnection-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("dataplicityConnection", "all")%</span>
+        <span id="uptime-mezmoLogging-all" class="uptime-percentage" style="display: none;">@Model.GetUptimePercentage("mezmoLogging", "all")%</span>
+        <p></p>
+    </div>
     <table id="eventsTable" class="table">
         <thead>
             <tr>


### PR DESCRIPTION
Addresses part of #289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the status legend with a new "Up%" indicator that clearly displays the S3 stream's uptime over the past week.
  
- **Refactor**
  - Reinstated uptime percentage displays in the events view to ensure a consistent presentation of status indicators across different time ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->