### PR TITLE
Add background color to dB columns on dashboard

### DIFF
--- a/OrcanodeMonitor/Pages/DataplicityNode.cshtml.cs
+++ b/OrcanodeMonitor/Pages/DataplicityNode.cshtml.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
@@ -46,6 +47,10 @@ namespace OrcanodeMonitor.Pages
         {
             _serial = serial;
             string rawJson = await Fetcher.GetDataplicityDataAsync(serial, _logger);
+            if (rawJson.IsNullOrEmpty())
+            {
+                return NotFound(); // Returns a 404 error page
+            }
             var formatter = new JsonFormatter();
             _jsonData = formatter.FormatJson(rawJson);
             return Page();

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -67,10 +67,10 @@
                     @Model.GetUptimePercentage(item)%
                 </a>
             </td>
-            <td>
+            <td style="background-color: @Model.NodeRealDecibelLevelBackgroundColor(item)">
                 @Html.DisplayFor(modelItem => item.RealDecibelLevelForDisplay)
             </td>
-            <td>
+            <td style="background-color: @Model.NodeHumDecibelLevelBackgroundColor(item)">
                 @Html.DisplayFor(modelItem => item.HumDecibelLevelForDisplay)
             </td>
             @if (item.OrcaHelloStatus == Models.OrcanodeOnlineStatus.Absent)
@@ -109,7 +109,7 @@
             <td style="background-color: @Model.NodeDataplicityUpgradeColor(item)">
                 @Html.DisplayFor(modelItem => item.AgentVersion)
             </td>
-            <td>
+            <td style="background-color: @Model.NodeDiskUsagePercentageColor(item)">
                 @Html.DisplayFor(modelItem => item.DiskUsedInGigs)/@Html.DisplayFor(modelItem => item.DiskCapacityInGigs)G
                 (@Html.DisplayFor(modelItem => item.DiskUsagePercentage)%)
             </td>

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -3,7 +3,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json.Linq;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -3,6 +3,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 using OrcanodeMonitor.Core;
 using OrcanodeMonitor.Data;
 using OrcanodeMonitor.Models;
@@ -53,7 +54,7 @@ namespace OrcanodeMonitor.Pages
             }
             if (orcasoundStatus.HasValue && (orcasoundStatus != OrcanodeOnlineStatus.Online))
             {
-                return ColorTranslator.ToHtml(Color.FromArgb(0xff, 0xcc, 0xcb));
+                return ColorTranslator.ToHtml(LightRed);
             }
             return ColorTranslator.ToHtml(Color.Red);
         }
@@ -109,12 +110,52 @@ namespace OrcanodeMonitor.Pages
             string color = GetBackgroundColor(node.OrcasoundStatus);
             if ((node.Type != "Live") && (color == ColorTranslator.ToHtml(Color.Red)))
             {
-                return ColorTranslator.ToHtml(Color.FromArgb(0xff, 0xcc, 0xcb));
+                return ColorTranslator.ToHtml(LightRed);
             }
             return color;
         }
 
+        private Color LightRed => Color.FromArgb(0xff, 0xcc, 0xcb);
+
         public string NodeOrcasoundTextColor(Orcanode node) => GetTextColor(NodeOrcasoundBackgroundColor(node));
+
+        public string NodeRealDecibelLevelBackgroundColor(Orcanode node)
+        {
+            string value = node.RealDecibelLevelForDisplay;
+            if (value == "N/A")
+            {
+                return ColorTranslator.ToHtml(LightRed);
+            }
+            long level = long.Parse(value);
+            if (level < FrequencyInfo.MinNoiseDecibels)
+            {
+                return ColorTranslator.ToHtml(LightRed);
+            }
+            if (level < FrequencyInfo.MaxSilenceDecibels)
+            {
+                return ColorTranslator.ToHtml(Color.Yellow);
+            }
+            return ColorTranslator.ToHtml(Color.LightGreen);
+        }
+
+        public string NodeHumDecibelLevelBackgroundColor(Orcanode node)
+        {
+            string value = node.HumDecibelLevelForDisplay;
+            if (value == "N/A")
+            {
+                return ColorTranslator.ToHtml(LightRed);
+            }
+            long level = long.Parse(value);
+            if (level < FrequencyInfo.MinNoiseDecibels)
+            {
+                return ColorTranslator.ToHtml(Color.LightGreen);
+            }
+            if (level < FrequencyInfo.MaxSilenceDecibels)
+            {
+                return ColorTranslator.ToHtml(Color.Yellow);
+            }
+            return ColorTranslator.ToHtml(LightRed);
+        }
 
         private DateTime SinceTime => DateTime.UtcNow.AddDays(-7);
 
@@ -127,7 +168,7 @@ namespace OrcanodeMonitor.Pages
             {
                 if (node.OrcasoundStatus != OrcanodeOnlineStatus.Online)
                 {
-                    return ColorTranslator.ToHtml(Color.FromArgb(0xff, 0xcc, 0xcb));
+                    return ColorTranslator.ToHtml(LightRed);
                 }
                 return ColorTranslator.ToHtml(Color.Red);
             }
@@ -148,6 +189,20 @@ namespace OrcanodeMonitor.Pages
                 return ColorTranslator.ToHtml(Color.Yellow);
             }
             return ColorTranslator.ToHtml(Color.LightGreen);
+        }
+
+        public string NodeDiskUsagePercentageColor(Orcanode node)
+        {
+            long percentage = node.DiskUsagePercentage;
+            if (percentage < 75)
+            {
+                return ColorTranslator.ToHtml(Color.LightGreen);
+            }
+            if (percentage < 90)
+            {
+                return ColorTranslator.ToHtml(Color.Yellow);
+            }
+            return ColorTranslator.ToHtml(Color.Red);
         }
 
         public async Task OnGetAsync()


### PR DESCRIPTION
Also add an error check for when dataplicity token expires so as to not crash.

Fixes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added background color highlights to the "Real dB", "Hum dB", and "SD Card Util." columns in the dashboard, providing visual cues based on node data.
- **Bug Fixes**
  - Improved error handling for missing or empty node data, displaying a 404 error when appropriate.
- **Style**
  - Standardized color usage for decibel and disk usage indicators for a more consistent visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->