### PR TITLE
Add config option to use database as read-only

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -28,6 +28,7 @@ namespace OrcanodeMonitor.Core
         private static string _orcaHelloHydrophonesUrl = "https://aifororcasdetections2.azurewebsites.net/api/hydrophones";
         private static DateTime _unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         private static string _iftttServiceKey = Environment.GetEnvironmentVariable("IFTTT_SERVICE_KEY") ?? "<unknown>";
+        public static bool IsReadOnly = false;
         private static string _defaultProdS3Bucket = "audio-orcasound-net";
         private static string _defaultDevS3Bucket = "dev-streaming-orcasound-net";
         public static string IftttServiceKey => _iftttServiceKey;
@@ -244,7 +245,7 @@ namespace OrcanodeMonitor.Core
                 }
 
                 MonitorState.GetFrom(context).LastUpdatedTimestampUtc = DateTime.UtcNow;
-                await context.SaveChangesAsync();
+                await SaveChangesAsync(context);
             }
             catch (Exception ex)
             {
@@ -388,7 +389,7 @@ namespace OrcanodeMonitor.Core
                     {
                         // Save changes to make the node have an ID before we can
                         // possibly generate any events.
-                        await context.SaveChangesAsync();
+                        await SaveChangesAsync(context);
                     }
 
                     // Trigger any event changes.
@@ -421,7 +422,7 @@ namespace OrcanodeMonitor.Core
                 }
 
                 MonitorState.GetFrom(context).LastUpdatedTimestampUtc = DateTime.UtcNow;
-                await context.SaveChangesAsync();
+                await SaveChangesAsync(context);
             }
             catch (Exception ex)
             {
@@ -613,6 +614,14 @@ namespace OrcanodeMonitor.Core
             }
         }
 
+        private static async Task SaveChangesAsync(OrcanodeMonitorContext context)
+        {
+            if (!IsReadOnly)
+            {
+                await context.SaveChangesAsync();
+            }
+        }
+
         /// <summary>
         /// Update the current list of Orcanodes using data from orcasound.net.
         /// </summary>
@@ -641,7 +650,7 @@ namespace OrcanodeMonitor.Core
                 }
 
                 MonitorState.GetFrom(context).LastUpdatedTimestampUtc = DateTime.UtcNow;
-                await context.SaveChangesAsync();
+                await SaveChangesAsync(context);
             }
             catch (Exception ex)
             {
@@ -663,7 +672,7 @@ namespace OrcanodeMonitor.Core
                 }
 
                 MonitorState.GetFrom(context).LastUpdatedTimestampUtc = DateTime.UtcNow;
-                await context.SaveChangesAsync();
+                await SaveChangesAsync(context);
             }
             catch (Exception ex)
             {

--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -614,6 +614,11 @@ namespace OrcanodeMonitor.Core
             }
         }
 
+        /// <summary>
+        /// Saves changes to the database if the application is not in read-only mode.
+        /// </summary>
+        /// <param name="context">The database context to save changes for.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         private static async Task SaveChangesAsync(OrcanodeMonitorContext context)
         {
             if (!IsReadOnly)

--- a/OrcanodeMonitor/Program.cs
+++ b/OrcanodeMonitor/Program.cs
@@ -18,6 +18,12 @@ if (connection.IsNullOrEmpty())
     connection = builder.Configuration.GetConnectionString("OrcanodeMonitorContext") ?? throw new InvalidOperationException("Connection string 'OrcanodeMonitorContext' not found.");
 }
 
+string isReadOnly = Environment.GetEnvironmentVariable("ORCANODE_MONITOR_READONLY") ?? "false";
+if (isReadOnly == "true")
+{
+    Fetcher.IsReadOnly = true;
+}
+
 string databaseName = Environment.GetEnvironmentVariable("AZURE_COSMOS_DATABASENAME") ?? "orcasound-cosmosdb";
 
 // Add services to the container.

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -103,7 +103,7 @@ The following state will be stored per orcanode:
 
 **AZURE_COSMOS_CONNECTIONSTRING**: The connection string for the Cosmos database to use.
 
-**ORCANODE_MONITOR_READONLY**: If set to "true", the Cosmos database is not updated.
+**ORCANODE_MONITOR_READONLY**: If set to "true", the Cosmos database is not updated by the Orcanode Monitor service. The service will continue to read data but will skip all database write operations.
 
 **IFTTT_SERVICE_KEY**: If-This-Then-That service key as provided via the ifttt.com service.
 

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -103,6 +103,8 @@ The following state will be stored per orcanode:
 
 **AZURE_COSMOS_CONNECTIONSTRING**: The connection string for the Cosmos database to use.
 
+**ORCANODE_MONITOR_READONLY**: If set to "true", the Cosmos database is not updated.
+
 **IFTTT_SERVICE_KEY**: If-This-Then-That service key as provided via the ifttt.com service.
 
 **ORCASOUND_DATAPLICITY_TOKEN**: Security token that allows reading state from Dataplicity.


### PR DESCRIPTION
Fixes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a read-only mode configurable via the ORCANODE_MONITOR_READONLY environment variable that disables database updates while allowing data reads.
- **Documentation**
  - Added details about the read-only mode configuration to the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->