### PR TITLE
Treat negative infinite db the same as no data

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -1011,7 +1011,7 @@ namespace OrcanodeMonitor.Core
 
                 // Compute an exponential weighted moving average of the non-hum decibel level.
                 double newValue = frequencyInfo.GetAverageNonHumDecibels();
-                if (node.DecibelLevel == null)
+                if (node.DecibelLevel == null || node.DecibelLevel == double.NegativeInfinity)
                 {
                     node.DecibelLevel = newValue;
                 }
@@ -1024,7 +1024,7 @@ namespace OrcanodeMonitor.Core
 
                 // Do the same for the hum decibel level.
                 newValue = frequencyInfo.GetAverageHumDecibels();
-                if (node.HumDecibelLevel == null)
+                if (node.HumDecibelLevel == null || node.HumDecibelLevel == double.NegativeInfinity)
                 {
                     node.HumDecibelLevel = newValue;
                 }

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -178,23 +178,23 @@ namespace OrcanodeMonitor.Models
         public double? AudioStandardDeviation { get; set; }
 
         /// <summary>
-        /// Measure of real volume.
+        /// Measure of real volume.  Negative infinity is absolute silence.
         /// </summary>
         public double? DecibelLevel { get; set; }
 
         public string RealDecibelLevelForDisplay {
             get
             {
-                if (DecibelLevel == null || DecibelLevel == 0)
+                if (DecibelLevel == null || DecibelLevel == double.NegativeInfinity)
                 {
                     return "N/A";
                 }
-                return ((int)Math.Round(DecibelLevel ?? 0)).ToString();
+                return ((int)Math.Round(DecibelLevel ?? double.NegativeInfinity)).ToString();
             }
         }
 
         /// <summary>
-        /// Measure of hum volume.
+        /// Measure of hum volume. Negative infinity is absolute silence.
         /// </summary>
         public double? HumDecibelLevel { get; set; }
 
@@ -202,11 +202,11 @@ namespace OrcanodeMonitor.Models
         {
             get
             {
-                if (HumDecibelLevel == null || HumDecibelLevel == 0)
+                if (HumDecibelLevel == null || HumDecibelLevel == double.NegativeInfinity)
                 {
                     return "N/A";
                 }
-                return ((int)Math.Round(HumDecibelLevel ?? 0)).ToString();
+                return ((int)Math.Round(HumDecibelLevel ?? double.NegativeInfinity)).ToString();
             }
         }
 


### PR DESCRIPTION
Fixes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Decibel level readings now correctly handle cases where values are set to negative infinity, ensuring accurate display and initialization.
- **Documentation**
	- Updated property descriptions to clarify that negative infinity represents absolute silence in decibel level readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->