### PR TITLE
Add event type filter to bottom of dashboard

### DIFF
--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -197,21 +197,108 @@
     </ul>
     <p/>
     <h1 class="display-4"><a href="/api/ifttt/v1/triggers/nodestateevents">Recent State Events</a></h1>
-    <table>
+    <!-- Filter Buttons for Type -->
+    <div>
+        Filter by Type:
+        <button id="btn-type-all" class="btn unselected" onclick="updateFilter('type', 'all')">All</button>
+        <button id="btn-type-hydrophoneStream" class="btn selected" onclick="updateFilter('type', 'hydrophoneStream')">Hydrophone Stream</button>
+        <button id="btn-type-dataplicityConnection" class="btn unselected" onclick="updateFilter('type', 'dataplicityConnection')">Dataplicity Connection</button>
+        <button id="btn-type-mezmoLogging" class="btn unselected" onclick="updateFilter('type', 'mezmoLogging')">Mezmo Logging</button>
+        <p></p>
+    </div>
+    <table id="eventsTable" class="table">
         <thead>
             <tr>
                 <th>Timestamp (Pacific)</th>
-                <th>Event</th>
+                <th align="left">Event</th>
             </tr>
         </thead>
         <tbody>
-            @foreach (Models.OrcanodeEvent item in Model.RecentEvents)
+            @if (!Model.RecentEvents.Any())
             {
                 <tr>
+                    <td colspan="2" class="text-center">No events found for this time period.</td>
+                </tr>
+            }
+            @foreach (Models.OrcanodeEvent item in Model.RecentEvents)
+            {
+                <tr class="@Model.GetEventClasses(item)">
                     <td>@item.DateTimeLocal.ToString("g")</td>
                     <td align="left">@item.Description</td>
                 </tr>
             }
         </tbody>
     </table>
+
+    <script>
+        var currentFilters = {
+            timeRange: 'pastWeek',
+            type: 'hydrophoneStream' };
+
+        updateFilter('default', 'default');
+
+        function updateFilter(filterType, filterValue) {
+            // Update time range filter.
+            if (filterType == 'timeRange') {
+                var oldTimeRangeButtonId = 'btn-timeRange-' + currentFilters.timeRange;
+                var oldTimeRangeButton = document.getElementById(oldTimeRangeButtonId);
+                oldTimeRangeButton.classList.remove('selected');
+                oldTimeRangeButton.classList.add('unselected');
+
+                currentFilters.timeRange = filterValue;
+
+                var newTimeRangeButtonId = 'btn-timeRange-' + currentFilters.timeRange;
+                var newTimeRangeButton = document.getElementById(newTimeRangeButtonId);
+                newTimeRangeButton.classList.remove('unselected');
+                newTimeRangeButton.classList.add('selected');
+            }
+
+            // Update type filter.
+            if (filterType == 'type') {
+                var oldTypeButtonId = 'btn-type-' + currentFilters.type;
+                var oldTypeButton = document.getElementById(oldTypeButtonId);
+                oldTypeButton.classList.remove('selected');
+                oldTypeButton.classList.add('unselected');
+
+                currentFilters.type = filterValue;
+
+                var newTypeButtonId = 'btn-type-' + currentFilters.type;
+                var newTypeButton = document.getElementById(newTypeButtonId);
+                newTypeButton.classList.remove('unselected');
+                newTypeButton.classList.add('selected');
+            }
+
+            filterTable();
+            showUptimePercentage("uptime-" + currentFilters.type + "-" + currentFilters.timeRange);
+        }
+
+        function filterTable() {
+            // Get all rows from the table.
+            var rows = document.querySelectorAll('#eventsTable tbody tr');
+
+            // Loop through each row.
+            rows.forEach(function(row) {
+                // Check if the row matches the selected time range and type
+                var matchesTimeRange = (currentFilters.timeRange === 'all' || row.classList.contains(currentFilters.timeRange));
+                var matchesType = (currentFilters.type === 'all' || row.classList.contains(currentFilters.type));
+
+                if (matchesTimeRange && matchesType) {
+                    row.style.display = ''; // Show matching rows.
+                } else {
+                    row.style.display = 'none'; // Hide non-matching rows.
+                }
+            });
+        }
+
+        function showUptimePercentage(id) {
+            // Hide all uptime percentage elements.
+            var elements = document.querySelectorAll('.uptime-percentage');
+            elements.forEach(function(element) {
+                element.style.display = 'none';
+            });
+
+            // Show the selected uptime percentage.
+            document.getElementById(id).style.display = '';
+        }
+    </script>
  </div>

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -220,5 +220,11 @@ namespace OrcanodeMonitor.Pages
             var events = await _databaseContext.OrcanodeEvents.ToListAsync();
             _events = events.Where(e => e.Type == OrcanodeEventTypes.HydrophoneStream).ToList();
         }
+
+        public string GetEventClasses(OrcanodeEvent item)
+        {
+            string classes = NodeEventsModel.GetTypeClass(item) + " " + NodeEventsModel.GetTimeRangeClass(item);
+            return classes;
+        }
     }
 }

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -151,7 +151,7 @@ namespace OrcanodeMonitor.Pages
             FetchEvents(_logger);
         }
 
-        public string GetTypeClass(OrcanodeEvent item) => item.Type switch
+        public static string GetTypeClass(OrcanodeEvent item) => item.Type switch
         {
             OrcanodeEventTypes.HydrophoneStream => "hydrophoneStream",
             OrcanodeEventTypes.DataplicityConnection => "dataplicityConnection",
@@ -161,7 +161,7 @@ namespace OrcanodeMonitor.Pages
             _ => string.Empty
         };
 
-        public string GetTimeRangeClass(OrcanodeEvent item)
+        public static string GetTimeRangeClass(OrcanodeEvent item)
         {
             DateTime OneWeekAgo = DateTime.UtcNow.AddDays(-7);
             if (item.DateTimeUtc > OneWeekAgo) {


### PR DESCRIPTION
Fixes #299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive filter buttons above the "Recent State Events" table, allowing users to filter events by type (All, Hydrophone Stream, Dataplicity Connection, Mezmo Logging).
  - The events table now dynamically updates to show or hide rows based on the selected filter.
  - A message is displayed when no events match the selected filter.

- **Style**
  - Updated table and filter button styling for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->