### PR TITLE
Display decibels on SpectralDensity page stats summary

### DIFF
--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -127,6 +127,8 @@
             Total magnitude outside hum range: @Model.TotalNonHumMagnitude <br />
             Total magnitude of hum range: @Model.TotalHumMagnitude <br />
             Signal ratio: @Model.SignalRatio %<br />
+            Average decibels outside hum range: @Model.AverageHumDecibels <br />
+            Average decibels of hum: @Model.AverageHumDecibels <br />
             Status: @Model.Status <br />
         </p>
         @if (Model.ChannelCount > 1)
@@ -140,6 +142,8 @@
                     Total magnitude outside hum range: @Model.GetTotalNonHumMagnitude(i) <br />
                     Total magnitude of hum range: @Model.GetTotalHumMagnitude(i) <br />
                     Signal ratio: @Model.GetSignalRatio(i) %<br />
+                    Average decibels outside hum range: @Model.GetAverageHumDecibels(i) <br />
+                    Average decibels of hum: @Model.GetAverageHumDecibels(i) <br />
                     Status: @Model.GetStatus(i) <br />
                 </p>
             }

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -127,7 +127,7 @@
             Total magnitude outside hum range: @Model.TotalNonHumMagnitude <br />
             Total magnitude of hum range: @Model.TotalHumMagnitude <br />
             Signal ratio: @Model.SignalRatio %<br />
-            Average decibels outside hum range: @Model.AverageHumDecibels <br />
+            Average decibels outside hum range: @Model.AverageNonHumDecibels <br />
             Average decibels of hum: @Model.AverageHumDecibels <br />
             Status: @Model.Status <br />
         </p>
@@ -142,7 +142,7 @@
                     Total magnitude outside hum range: @Model.GetTotalNonHumMagnitude(i) <br />
                     Total magnitude of hum range: @Model.GetTotalHumMagnitude(i) <br />
                     Signal ratio: @Model.GetSignalRatio(i) %<br />
-                    Average decibels outside hum range: @Model.GetAverageHumDecibels(i) <br />
+                    Average decibels outside hum range: @Model.GetAverageNonHumDecibels(i) <br />
                     Average decibels of hum: @Model.GetAverageHumDecibels(i) <br />
                     Status: @Model.GetStatus(i) <br />
                 </p>

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -32,6 +32,10 @@ namespace OrcanodeMonitor.Pages
         public double TotalHumMagnitude => _totalHumMagnitude;
         private double _totalHumMagnitude;
         private double _totalNonHumMagnitude;
+        private double _averageHumDecibels;
+        private double _averageNonHumDecibels;
+        public double AverageHumDecibels => _averageHumDecibels;
+        public double AverageNonHumDecibels => _averageNonHumDecibels;
         private FrequencyInfo? _frequencyInfo = null;
         public double MaxNonHumMagnitude { get; private set; }
         public int SignalRatio { get; private set; }
@@ -180,6 +184,8 @@ namespace OrcanodeMonitor.Pages
             Status = Orcanode.GetStatusString(_frequencyInfo.Status);
             _totalHumMagnitude = _frequencyInfo.GetTotalHumMagnitude();
             _totalNonHumMagnitude = _frequencyInfo.GetTotalNonHumMagnitude();
+            _averageHumDecibels = _frequencyInfo.GetAverageHumDecibels();
+            _averageNonHumDecibels = _frequencyInfo.GetAverageNonHumDecibels();
             SignalRatio = (int)Math.Round(100 * _frequencyInfo.GetSignalRatio());
         }
 
@@ -227,6 +233,8 @@ namespace OrcanodeMonitor.Pages
         public double GetTotalHumMagnitude(int channel) => _frequencyInfo?.GetTotalHumMagnitude(channel) ?? 0;
 
         public double GetTotalNonHumMagnitude(int channel) => _frequencyInfo?.GetTotalNonHumMagnitude(channel) ?? 0;
+        public double GetAverageHumDecibels(int channel) => _frequencyInfo?.GetAverageHumDecibels(channel) ?? double.NaN;
+        public double GetAverageNonHumDecibels(int channel) => _frequencyInfo?.GetAverageNonHumDecibels(channel) ?? double.NaN;
 
         public int GetSignalRatio(int channel) => (int)Math.Round(100 * _frequencyInfo?.GetSignalRatio(channel) ?? 0);
 


### PR DESCRIPTION
Addresses #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added display of "Average decibels outside hum range" and "Average decibels of hum" in both the summary statistics and per-channel statistics sections of the Spectral Density page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->