### PR TITLE
Switching to Absent should log an event

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -802,9 +802,17 @@ namespace OrcanodeMonitor.Core
         /// <returns></returns>
         public async static Task UpdateS3DataAsync(OrcanodeMonitorContext context, Orcanode node, ILogger logger)
         {
+            OrcanodeOnlineStatus oldStatus = node.S3StreamStatus;
             TimestampResult? result = await GetLatestS3TimestampAsync(node, true, logger);
             if (result == null)
             {
+                OrcanodeOnlineStatus newStatus = node.S3StreamStatus;
+                if (newStatus != oldStatus)
+                {
+                    // Log event if it just went absent. Other events will be logged
+                    // inside the call to UpdateManifestTimestampAsync() below.
+                    AddHydrophoneStreamStatusEvent(context, node, null);
+                }
                 return;
             }
             string unixTimestampString = result.UnixTimestampString;


### PR DESCRIPTION
Fixes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event logging for S3 stream status changes to prevent redundant notifications when a node goes absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->