### PR TITLE
Label as local time on top of SpectralDensity page

### DIFF
--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml
@@ -7,7 +7,7 @@
 <script src="https://cdn.jsdelivr.net/npm/mpegts.js@1.8.0/dist/mpegts.min.js"></script>
 <div class="text-center">
     <h1 class="display-4">Spectral Density of Audio From @Model.NodeName</h1>
-    As of: @Model.LastModified<br />
+    As of: @Model.LastModifiedLocal (Pacific)<br />
 
     <!-- Include Chart.js from CDN -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1"></script>

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -259,7 +259,7 @@ namespace OrcanodeMonitor.Pages
                     UpdateFrequencyInfo();
 
                     // Use local time.
-                    LastModifiedLocal = DateTime.Now.ToString();
+                    LastModifiedLocal = Fetcher.UtcToLocalDateTime(DateTime.UtcNow)?.ToString() ?? "Unknown";
                 }
                 catch (Exception ex)
                 {
@@ -282,7 +282,7 @@ namespace OrcanodeMonitor.Pages
             }
 
             DateTime? lastModified = await Fetcher.GetLastModifiedAsync(uri);
-            LastModifiedLocal = lastModified?.ToLocalTime().ToString() ?? "Unknown";
+            LastModifiedLocal = UtcToLocalDateTime(lastModified)?.ToString() ?? "Unknown";
 
             try
             {

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -47,7 +47,11 @@ namespace OrcanodeMonitor.Pages
         }
         public double MaxSilenceDecibels => FrequencyInfo.MaxSilenceDecibels;
         public double MinNoiseDecibels => FrequencyInfo.MinNoiseDecibels;
-        public string LastModified { get; private set; }
+
+        /// <summary>
+        /// Last modified timestamp, in local time.
+        /// </summary>
+        public string LastModifiedLocal { get; private set; }
 
         public SpectralDensityModel(OrcanodeMonitorContext context, ILogger<SpectralDensityModel> logger)
         {
@@ -56,7 +60,7 @@ namespace OrcanodeMonitor.Pages
             _id = string.Empty;
             Status = string.Empty;
             _labels = new List<string>();
-            LastModified = string.Empty;
+            LastModifiedLocal = string.Empty;
         }
 
         /// <summary>
@@ -255,7 +259,7 @@ namespace OrcanodeMonitor.Pages
                     UpdateFrequencyInfo();
 
                     // Use local time.
-                    LastModified = DateTime.Now.ToString();
+                    LastModifiedLocal = DateTime.Now.ToString();
                 }
                 catch (Exception ex)
                 {
@@ -278,7 +282,7 @@ namespace OrcanodeMonitor.Pages
             }
 
             DateTime? lastModified = await Fetcher.GetLastModifiedAsync(uri);
-            LastModified = lastModified?.ToLocalTime().ToString() ?? "Unknown";
+            LastModifiedLocal = lastModified?.ToLocalTime().ToString() ?? "Unknown";
 
             try
             {


### PR DESCRIPTION
This changes the label but doesn't fix the apparent bug even though the code looks correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the displayed timestamp on the Spectral Density page to show the last modified time in Pacific local time, providing clearer context for users in that time zone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->