### PR TITLE
Fix URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/orcasound/orcanode-monitor/badge)](https://scorecard.dev/viewer/?uri=github.com/orcasound/orcanode-monitor)
 
-[Orcanode Monitor](https://orcanodemonitor2.azurewebsites.net/) is a web service for monitoring liveness of [orcanode](https://github.com/orcasound/orcanode) audio streaming.
+[Orcanode Monitor](https://orcanodemonitor.azurewebsites.net/) is a web service for monitoring liveness of [orcanode](https://github.com/orcasound/orcanode) audio streaming.
 
 The troubleshooting guide at
 [Administration of network nodes](https://github.com/orcasound/orcanode/wiki/Administration-of-network-nodes#general-trouble-shooting-strategies-for-orcasound-nodes)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Orcanode Monitor hyperlink in the README to point to the correct URL (https://orcanodemonitor.azurewebsites.net/), ensuring users are directed to the current monitoring site.
  - No changes to link text or surrounding content; only the destination was updated.
  - No impact on application behavior or interfaces; this is a documentation-only improvement aimed at accuracy and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->