### PR TITLE
Update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,10 @@ updates:
           - "*"
 
   - package-ecosystem: nuget
-    directory: /OrcanodeMonitor
+    directories:
+      - "/OrcanodeMonitor"
+      - "/Test"
+      - "/TransferData"
     schedule:
       interval: weekly
       day: "saturday"
@@ -25,21 +28,7 @@ updates:
       actions:
         patterns:
           - "*"
-
-  - package-ecosystem: nuget
-    directory: /Test
-    schedule:
-      interval: daily
-    groups:
-      actions:
-        patterns:
-          - "*"
-
-  - package-ecosystem: nuget
-    directory: /TransferData
-    schedule:
-      interval: daily
-    groups:
-      actions:
-        patterns:
-          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Major version changes are by definition breaking changes and dependabot cannot change the things they break (e.g., the reason PR #398 failed tests). Non-major changes are backwards compatible and safe to update with dependabot.