### PR TITLE
Update orcahello links

### DIFF
--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -18,7 +18,7 @@
             <th>Up%</th>
             <th>Real dB</th>
             <th>Hum dB</th>
-            <th><a href="https://aifororcas2.azurewebsites.net/hydrophones" target="_blank">OrcaHello</a></th>
+            <th><a href="@Model.AksUrl" target="_blank">OrcaHello</a></th>
             <th><a href="https://app.mezmo.com/313dbd82f3/logs/view" target="_blank">Logging</a></th>
             <th><a href="https://www.dataplicity.com/app/" target="_blank">Dataplicity</a></th>
             <th>Agent Version</th>
@@ -82,7 +82,7 @@
             else
             {
                 <td style="background-color: @Model.NodeOrcaHelloBackgroundColor(item)">
-                    <a href="https://aifororcas2.azurewebsites.net/hydrophones" style="color: @Model.NodeOrcaHelloTextColor(item)" target="_blank">
+                        <a href="@Model.AksUrl" style="color: @Model.NodeOrcaHelloTextColor(item)" target="_blank">
                         @Html.DisplayFor(modelItem => item.OrcaHelloStatus)
                     </a>
                 </td>

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -20,6 +20,8 @@ namespace OrcanodeMonitor.Pages
         public List<OrcanodeEvent> RecentEvents => _recentEvents;
         private List<OrcanodeEvent> _recentEvents;
 
+        public string AksUrl => Environment.GetEnvironmentVariable("AZURE_AKS_URL") ?? "";
+
         public IndexModel(OrcanodeMonitorContext context, ILogger<IndexModel> logger)
         {
             _databaseContext = context;

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -99,29 +99,37 @@ The following state will be stored per orcanode:
 
 ### Configured parameters
 
-**AZURE_COSMOS_DATABASENAME**: The name of the Azure Cosmos database to use.
+**AZURE_AKS_URL**: The URL to go to when clicking on the OrcaHello column.  Typically the AKS workloads page.
 
 **AZURE_COSMOS_CONNECTIONSTRING**: The connection string for the Cosmos database to use.
 
-**ORCANODE_MONITOR_READONLY**: If set to "true", the Cosmos database is not updated by the Orcanode Monitor service. The service will continue to read data but will skip all database write operations.
+**AZURE_COSMOS_DATABASENAME**: The name of the Azure Cosmos database to use.
 
 **IFTTT_SERVICE_KEY**: If-This-Then-That service key as provided via the ifttt.com service.
 
-**ORCASOUND_DATAPLICITY_TOKEN**: Security token that allows reading state from Dataplicity.
+**KUBERNETES_CA_CERT**: The base64-encoded Kubernetes CA certificate, for checking Inference System status.  The value can be obtained from a ~/.kube/config file.
 
-**ORCASOUND_POLL_FREQUENCY_IN_MINUTES**: Service will poll each orcanode at the configured frequency. Default: 5
+**KUBERNETES_SERVICE_HOST**: The Kubernetes service host URL, for checking Inference System status.  The value can be obtained from a ~/.kube/config file.
 
-**ORCASOUND_REBOOT_HOUR_OFFSET_MINUTES**: The number of minutes from the top of the hour when reboot checks should occur. This allows multiple deployments (production and staging) to avoid conflicts by running at different times. Default: 0 (top of hour)
-
-**ORCASOUND_MAX_UPLOAD_DELAY_MINUTES**: If the manifest file is older than this, the node will be considered offline. Default: 2
+**KUBERNETES_TOKEN**: The Kubernetes token, for checking Inference System status.  The value can be obtained from a ~/.kube/config file.
 
 **MEZMO_LOG_SECONDS**: The number of seconds of Mezmo logs to check for activity. Default: 60
 
-**ORCASOUND_MIN_INTELLIGIBLE_SIGNAL_PERCENT**: The minimum percentage of total magnitude across all frequencies outside the hum range vs magnitude in hum range (multiples of 60 Hz), needed to determine that an audio stream is intelligible. Default: 1400
+**ORCANODE_MONITOR_READONLY**: If set to "true", the Cosmos database is not updated by the Orcanode Monitor service. The service will continue to read data but will skip all database write operations.
+
+**ORCASOUND_DATAPLICITY_TOKEN**: Security token that allows reading state from Dataplicity.
+
+**ORCASOUND_REBOOT_HOUR_OFFSET_MINUTES**: The number of minutes from the top of the hour when reboot checks should occur. This allows multiple deployments (production and staging) to avoid conflicts by running at different times. Default: 0 (top of hour)
 
 **ORCASOUND_MAX_SILENCE_DECIBELS**: The maximum decibel level at which a stream might still be considered unintelligible due to silence. Default: -80
 
+**ORCASOUND_MAX_UPLOAD_DELAY_MINUTES**: If the manifest file is older than this, the node will be considered offline. Default: 2
+
+**ORCASOUND_MIN_INTELLIGIBLE_SIGNAL_PERCENT**: The minimum percentage of total magnitude across all frequencies outside the hum range vs magnitude in hum range (multiples of 60 Hz), needed to determine that an audio stream is intelligible. Default: 1400
+
 **ORCASOUND_MIN_NOISE_DECIBELS**: The minimum decibel level at which a stream might still be considered intelligible. Default: -95
+
+**ORCASOUND_POLL_FREQUENCY_IN_MINUTES**: Service will poll each orcanode at the configured frequency. Default: 5
 
 These magnitude thresholds work together to implement hysteresis in the noise detection:
 - Magnitudes below ORCASOUND_MIN_NOISE_MAGNITUDE are always considered silent.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OrcaHello links in the dashboard header and node rows to use the configured AKS URL, ensuring consistent navigation and avoiding deprecated endpoints.

* **Documentation**
  * Revised configuration docs: replaced a Cosmos-centric parameter with the AKS URL, added Kubernetes credential settings, and restored several ORCASOUND/monitoring parameters with thresholds and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->