### PR TITLE
Skip benchmark pod

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -209,6 +209,14 @@ namespace OrcanodeMonitor.Core
                 {
                     continue;
                 }
+
+                // Only process inference-system pods, skipping any benchmark and other auxiliary pods.
+                var podName = pod.Metadata?.Name;
+                if (string.IsNullOrEmpty(podName) || !podName.StartsWith("inference-system"))
+                {
+                    continue;
+                }
+
                 foreach (V1ContainerStatus podStatus in pod.Status.ContainerStatuses)
                 {
                     if (IsBetterContainerStatus(bestPodStatus, podStatus))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod selection and health monitoring now consider only pods whose names start with "inference-system", improving accuracy of which pod is chosen as the primary candidate and reducing noisy or irrelevant status evaluations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->