### PR TITLE
Improve OrcaHello cells on dashboard

### DIFF
--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Orcanode Monitor contributors
 // SPDX-License-Identifier: MIT
 
-using System.Text.Json.Serialization;
 using Microsoft.IdentityModel.Tokens;
 using OrcanodeMonitor.Core;
+using System.Text.Json.Serialization;
 
 namespace OrcanodeMonitor.Models
 {
@@ -352,6 +352,25 @@ namespace OrcanodeMonitor.Models
             }
         }
 
+        /// <summary>
+        /// Check whether an OrcaHello container has been stable for a while.
+        /// </summary>
+        private bool IsOrcaHelloStable
+        {
+            get
+            {
+                if (OrcaHelloInferencePodRunningSince.HasValue)
+                {
+                    TimeSpan runTime = DateTime.UtcNow - OrcaHelloInferencePodRunningSince.Value;
+                    if (runTime > TimeSpan.FromMinutes(20))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
         public OrcanodeOnlineStatus OrcaHelloStatus
         {
             get
@@ -364,7 +383,7 @@ namespace OrcanodeMonitor.Models
                 {
                     return OrcanodeOnlineStatus.Offline;
                 }
-                if ((OrcaHelloInferenceRestartCount ?? 0) > 0)
+                if (((OrcaHelloInferenceRestartCount ?? 0) > 0) && !IsOrcaHelloStable)
                 {
                     return OrcanodeOnlineStatus.Unstable;
                 }

--- a/OrcanodeMonitor/Pages/Index.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Index.cshtml.cs
@@ -91,7 +91,8 @@ namespace OrcanodeMonitor.Pages
         public string NodeOrcaHelloStatus(Orcanode node)
         {
             var status = node.OrcaHelloStatus;
-            if ((status == OrcanodeOnlineStatus.Lagged) && (node.OrcaHelloInferencePodLag.HasValue))
+            if ((status == OrcanodeOnlineStatus.Lagged || status == OrcanodeOnlineStatus.Online) &&
+                (node.OrcaHelloInferencePodLag.HasValue))
             {
                 return $"{FormatTimeSpan(node.OrcaHelloInferencePodLag.Value)}";
             }
@@ -118,7 +119,7 @@ namespace OrcanodeMonitor.Pages
             if (since.HasValue)
             {
                 var ts = DateTime.UtcNow - since.Value;
-                if (ts > TimeSpan.FromDays(1))
+                if (ts > TimeSpan.FromHours(1))
                 {
                     return ColorTranslator.ToHtml(Color.LightGreen);
                 }


### PR DESCRIPTION
* Display lag for good nodes
* Display uptime > 1 hour (rather than 1 day) as green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined OrcaHello stability assessment using runtime duration and inference lag for smarter health evaluation.
  * Status view now shows inference pod lag in additional operational states for better visibility.
  * Uptime indicator becomes green after 1 hour of stable operation (previously 1 day).
  * Container restart handling adjusted based on the improved stability logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->