### PR TITLE
Fix some UI nits

### DIFF
--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -18,7 +18,7 @@
             <th>Up%</th>
             <th>Real dB</th>
             <th>Hum dB</th>
-            <th><a asp-page="/OrcaHelloOverview" target="_blank">OrcaHello Lag</a></th>
+            <th><a asp-page="/OrcaHelloOverview" target="_blank">OrcaHello</a> Lag</th>
             <th>OrcaHello Uptime</th>
             <th><a href="https://app.mezmo.com/313dbd82f3/logs/view" target="_blank">Logging</a></th>
             <th><a href="https://www.dataplicity.com/app/" target="_blank">Dataplicity</a></th>

--- a/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml
+++ b/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml
@@ -5,7 +5,8 @@
 }
 
 <div class="text-center">
-    <h1 class="display-4"><a href="@Model.AksUrl" target="_blank">OrcaHello Overview</a></h1>
+    <h1 class="display-4"><a href="@Model.AksUrl" target="_blank">OrcaHello</a> Overview</h1>
+    As of: @Model.NowLocal (Pacific)<br />
     <h2>Nodes</h2>
     <table>
         <tr>

--- a/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml.cs
+++ b/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml.cs
@@ -23,7 +23,14 @@ namespace OrcanodeMonitor.Pages
             Nodes = new List<OrcaHelloNode>();
             Containers = new List<OrcaHelloContainer>();
             Orcanodes = new List<Orcanode>();
+            NowLocal = Fetcher.UtcToLocalDateTime(DateTime.UtcNow)?.ToString() ?? "Unknown";
+
         }
+
+        /// <summary>
+        /// Current timestamp, in local time.
+        /// </summary>
+        public string NowLocal { get; private set; }
 
         /// <summary>
         /// Get a list of Kubernetes namespaces of pods running on a given node.

--- a/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
+++ b/OrcanodeMonitor/Pages/SpectralDensity.cshtml.cs
@@ -59,6 +59,9 @@ namespace OrcanodeMonitor.Pages
             _id = string.Empty;
             Status = string.Empty;
             LastModifiedLocal = string.Empty;
+            JsonChannelDatasets = string.Empty;
+            JsonHumChannelDatasets = string.Empty;
+            JsonNonHumChannelDatasets = string.Empty;
         }
 
         private void UpdateFrequencyInfo()


### PR DESCRIPTION
* Make OrcaHello link not include the word after it like Lag or Overview
* Add current timestamp to top of OrcaHelloOverview page
* Clean up some warnings in SpectralDensity page code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OrcaHello Overview page now displays current Pacific time with an "As of" timestamp indicator, providing better context for data currency

* **UI Updates**
  * Improved visual consistency by refining how OrcaHello headers and column labels are formatted and presented across monitoring pages and sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->