### PR TITLE
More OrcaHelloOverview UI updates

### DIFF
--- a/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml
+++ b/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml
@@ -11,8 +11,8 @@
     <table>
         <tr>
             <th>Name</th>
-            <th>CPU%</th>
-            <th>Memory%</th>
+            <th>CPU</th>
+            <th>Memory</th>
             <th>AVX-512</th>
             <th>Locations</th>
         </tr>
@@ -26,7 +26,7 @@
                     @(Math.Round(item.CpuPercent))%
                 </td>
                 <td>
-                    @(Math.Round(item.MemoryPercent))%
+                    @Model.GetNodeMemoryUsage(item) (@(Math.Round(item.MemoryPercent))%)
                 </td>
                 <td>
                     @(item.HasAvx512 ? "Yes" : "No")
@@ -43,8 +43,8 @@
         <tr>
             <th>Location</th>
             <th>Lag</th>
-            <th>CPU%</th>
-            <th>Memory%</th>
+            <th>CPU</th>
+            <th>Memory</th>
             <th>Image</th>
             <th>Node</th>
             <th>Last Error</th>

--- a/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml.cs
+++ b/OrcanodeMonitor/Pages/OrcaHelloOverview.cshtml.cs
@@ -16,6 +16,11 @@ namespace OrcanodeMonitor.Pages
         public List<OrcaHelloNode> Nodes { get; private set; }
         public List<OrcaHelloContainer> Containers { get; private set; }
         public string AksUrl => Environment.GetEnvironmentVariable("AZURE_AKS_URL") ?? "";
+        public string GetNodeMemoryUsage(OrcaHelloNode node)
+        {
+            long nodeMemoryUsageInKi = node.MemoryUsageInKi;
+            return $"{(nodeMemoryUsageInKi / 1024f / 1024f):F1} GiB";
+        }
         public OrcaHelloOverviewModel(OrcanodeMonitorContext context, ILogger<OrcaHelloOverviewModel> logger)
         {
             _databaseContext = context;


### PR DESCRIPTION
* Change UI label from Last Reason to Last Error on OrcaHelloOverview page
* Display node memory usage, not just %

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Renamed Pods table header "Last Reason" to "Last Error" for clarity.
  * Renamed Nodes and Pods CPU%/Memory% headers to "CPU" and "Memory".

* **New Features**
  * Nodes table now shows node memory as human-readable GiB followed by the previous memory percent in parentheses (e.g., "X.Y GiB (Z%)").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->