### PR TITLE
Fix timezone display on detections page

### DIFF
--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml
@@ -20,11 +20,11 @@
         <label for="sdTime">View Audio at:</label>
         <input id="sdTime" type="datetime-local" value="@formattedNow">
 
-        <button class="btn btn-primary" onclick="goToSpectralDensity()">
-            View Spectral Density
-        </button>
         <button class="btn btn-primary" onclick="goToOrcasite()">
             View on Orcasite
+        </button>
+        <button class="btn btn-primary" onclick="goToSpectralDensity()">
+            View Spectral Density
         </button>
     </div>
 </div>
@@ -80,7 +80,11 @@
             @foreach (Models.Detection item in Model.RecentDetections)
             {
                 <tr class="@Model.GetDetectionClasses(item)">
-                    <td>@item.Timestamp.ToLocalTime().ToString("g")</td>
+                    @{
+                        var pacific = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+                        var pacificTime = TimeZoneInfo.ConvertTimeFromUtc(item.Timestamp, pacific);
+                    }
+                    <td>@pacificTime.ToString("g")</td>
                     <td>@item.Category</td>
                     <td>@item.Source</td>
                     <td align="left">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps now display in Pacific Time instead of local time conversion for improved accuracy.

* **Style**
  * Reordered UI button placement for better layout consistency and navigation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->