### PR TITLE
Remove harden-runner from windows workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,6 @@ jobs:
       BUILD_CONFIGURATION: ${{matrix.configurations}}
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9  # v2.14.1
-        with:
-          egress-policy: audit
-
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf  # v5.3.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,6 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9  # v2.14.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309  # v5.1.0
@@ -44,11 +39,6 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9  # v2.14.1
-        with:
-          egress-policy: audit
-
       - name: Download artifact from build job
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,6 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9  # v2.14.1
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309  # v5.1.0
@@ -44,11 +39,6 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e3f713f2d8f53843e71c69a996d56f51aa9adfb9  # v2.14.1
-        with:
-          egress-policy: audit
-
       - name: Download artifact from build job
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:


### PR DESCRIPTION
harden-runner only works on Linux.
Removing this step prevents dependabot from filing useless PRs.

Fixes #471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified GitHub Actions workflows by removing the Harden Runner security step from build and deployment jobs across multiple pipeline configurations. All build, test, and deployment functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->