### PR TITLE
Handle null dataplicity disk stats

### DIFF
--- a/OrcanodeMonitor/Core/DataplicityFetcher.cs
+++ b/OrcanodeMonitor/Core/DataplicityFetcher.cs
@@ -234,19 +234,11 @@ namespace OrcanodeMonitor.Core
                     {
                         node.DiskCapacity = diskCapacityValue;
                     }
-                    else
-                    {
-                        node.DiskCapacity = 0;
-                    }
                     if (device.TryGetProperty("disk_used", out var diskUsed) &&
                         diskUsed.ValueKind == JsonValueKind.Number &&
                         diskUsed.TryGetInt64(out long diskUsedValue))
                     {
                         node.DiskUsed = diskUsedValue;
-                    }
-                    else
-                    {
-                        node.DiskUsed = 0;
                     }
                     if (device.TryGetProperty("upgrade_available", out var upgradeAvailable))
                     {


### PR DESCRIPTION
Sometimes dataplicity will return null instead of numbers.

Previously that resulted in an exception that prevented updating the dashboard with correct information.

Fixes #530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk space metric validation and parsing: disk capacity and usage are now more robustly checked before being applied, preventing invalid or missing values from corrupting reported metrics and ensuring more reliable disk space reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->