### PR TITLE
Remove ModelTimestamp

### DIFF
--- a/OrcanodeMonitor/Core/OrcaHelloFetcher.cs
+++ b/OrcanodeMonitor/Core/OrcaHelloFetcher.cs
@@ -371,23 +371,6 @@ namespace OrcanodeMonitor.Core
         }
 
         /// <summary>
-        /// Exec into a pod running to get model info.
-        /// </summary>
-        /// <param name="pod">Pod to exec into</param>
-        /// <param name="logger">Logger</param>
-        /// <returns>A task that represents the asynchronous operation. The task result contains the combined standard output and error from the command executed in the pod, as a string.</returns>
-        private async Task<string> GetPodModelTimestampAsync(V1Pod pod, ILogger logger)
-        {
-            if (pod.Metadata == null)
-            {
-                return string.Empty;
-            }
-
-            string[] command = { "stat", "-c", "%y", "/usr/src/app/model/model.pkl" };
-            return await GetPodCommandOutputAsync(pod.Metadata.Name, pod.Metadata.NamespaceProperty, command, logger);
-        }
-
-        /// <summary>
         /// Get model thresholds from the hydrophone-configs ConfigMap.
         /// </summary>
         /// <param name="namespaceName">Namespace name</param>
@@ -508,13 +491,11 @@ namespace OrcanodeMonitor.Core
             string cpuUsage = container?.Usage?.TryGetValue("cpu", out var cpu) == true ? cpu.ToString() : "0n";
             string memoryUsage = container?.Usage?.TryGetValue("memory", out var mem) == true ? mem.ToString() : "0Ki";
 
-            string modelTimestamp = await GetPodModelTimestampAsync(bestPod, logger);
-
             long detectionCount = await GetOrcaHelloDetectionCountAsync(orcanode, logger);
 
             (double? confidenceThreshold, int? countThreshold) = await GetModelThresholdsAsync(namespaceName, logger);
 
-            return new OrcaHelloPod(bestPod, cpuUsage, memoryUsage, modelTimestamp, detectionCount, confidenceThreshold, countThreshold);
+            return new OrcaHelloPod(bestPod, cpuUsage, memoryUsage, detectionCount, confidenceThreshold, countThreshold);
         }
 
         /// <summary>
@@ -919,7 +900,7 @@ namespace OrcanodeMonitor.Core
 
                     (double? confidenceThreshold, int? countThreshold) = await GetModelThresholdsAsync(pod.Metadata.NamespaceProperty, logger);
 
-                    var orcaHelloPod = new OrcaHelloPod(pod, cpuUsage, memoryUsage, modelTimestamp: string.Empty, detectionCount, confidenceThreshold, countThreshold);
+                    var orcaHelloPod = new OrcaHelloPod(pod, cpuUsage, memoryUsage, detectionCount, confidenceThreshold, countThreshold);
                     resultList.Add(orcaHelloPod);
                 }
             }

--- a/OrcanodeMonitor/Models/OrcaHelloNode.cs
+++ b/OrcanodeMonitor/Models/OrcaHelloNode.cs
@@ -138,7 +138,7 @@ namespace OrcanodeMonitor.Models
                 string cpuUsagePod = container?.Usage?.TryGetValue("cpu", out var cpu) == true ? cpu.ToString() : "0n";
                 string memoryUsagePod = container?.Usage?.TryGetValue("memory", out var mem) == true ? mem.ToString() : "0Ki";
 
-                OrcaHelloPod orcaPod = new OrcaHelloPod(pod, cpuUsagePod, memoryUsagePod, string.Empty, 0);
+                OrcaHelloPod orcaPod = new OrcaHelloPod(pod, cpuUsagePod, memoryUsagePod, 0);
                 _pods.Add(orcaPod);
             }
         }

--- a/OrcanodeMonitor/Models/OrcaHelloPod.cs
+++ b/OrcanodeMonitor/Models/OrcaHelloPod.cs
@@ -11,7 +11,6 @@ namespace OrcanodeMonitor.Models
         public string NamespaceName => _pod.Metadata?.NamespaceProperty ?? string.Empty;
         public string NodeName => _pod.Spec?.NodeName ?? string.Empty;
         public string LastTerminationReason { get; private set; }
-        public string ModelTimestamp { get; private set; }
         public double CpuUsageCores { get; private set; }
         public double CpuCapacityCores { get; private set; }
         public double CpuPercent => CpuCapacityCores > 0 ? (100.0 * CpuUsageCores / CpuCapacityCores) : 0;
@@ -55,10 +54,9 @@ namespace OrcanodeMonitor.Models
             }
         }
 
-        public OrcaHelloPod(V1Pod pod, string cpuUsage, string memoryUsage, string modelTimestamp, long detectionCount, double? modelConfidenceThreshold = null, int? modelCountThreshold = null)
+        public OrcaHelloPod(V1Pod pod, string cpuUsage, string memoryUsage, long detectionCount, double? modelConfidenceThreshold = null, int? modelCountThreshold = null)
         {
             _pod = pod;
-            ModelTimestamp = modelTimestamp;
             DetectionCount = detectionCount;
             ModelConfidenceThreshold = modelConfidenceThreshold;
             ModelCountThreshold = modelCountThreshold;

--- a/OrcanodeMonitor/Pages/OrcaHelloPod.cshtml
+++ b/OrcanodeMonitor/Pages/OrcaHelloPod.cshtml
@@ -5,7 +5,7 @@
 }
 
 <div class="text-center">
-    <h1 class="display-4"><a asp-page="/OrcaHelloOverview" target="_blank">OrcaHello</a> for @Model.Location</h1>
+    <h1 class="display-4">OrcaHello for @Model.Location</h1>
     As of: @Model.NowLocal (Pacific)<br />
     <div style="display: flex; gap: 20px;">
         <table style="border: 1px solid #ccc; border-collapse: separate;">
@@ -27,10 +27,6 @@
             <tr>
                 <td style="text-align: right; font-weight: bold; padding: 4px;">Image:</td>
                 <td style="text-align: left; padding: 4px;">@Model.ImageName</td>
-            </tr>
-            <tr>
-                <td style="text-align: right; font-weight: bold; padding: 4px;">Model Timestamp:</td>
-                <td style="text-align: left; padding: 4px;">@Model.ModelTimestamp</td>
             </tr>
             <tr>
                 <td style="text-align: right; font-weight: bold; padding: 4px;">Confidence Threshold:</td>

--- a/OrcanodeMonitor/Pages/OrcaHelloPod.cshtml.cs
+++ b/OrcanodeMonitor/Pages/OrcaHelloPod.cshtml.cs
@@ -25,7 +25,6 @@ namespace OrcanodeMonitor.Pages
         public string Namespace { get; set; }
         public string Name => _pod?.Name ?? "Unknown";
         public string ImageName => _pod?.ImageName ?? "Unknown";
-        public string ModelTimestamp => _pod?.ModelTimestamp ?? "Unknown";
         public double CpuCapacityCores => _pod?.CpuCapacityCores ?? 0;
         public double CpuUsageCores => _pod?.CpuUsageCores ?? 0;
         public double CpuPercent => _pod?.CpuPercent ?? 0;

--- a/Test/OrcaHelloTests.cs
+++ b/Test/OrcaHelloTests.cs
@@ -176,7 +176,6 @@ namespace Test
                 pod,
                 cpuUsage: "100000000n",
                 memoryUsage: "256Ki",
-                modelTimestamp: "2024-01-01",
                 detectionCount: 10,
                 modelConfidenceThreshold: 0.7,
                 modelCountThreshold: 3
@@ -197,7 +196,6 @@ namespace Test
                 pod,
                 cpuUsage: "100000000n",
                 memoryUsage: "256Ki",
-                modelTimestamp: "2024-01-01",
                 detectionCount: 10,
                 modelConfidenceThreshold: 0.7,
                 modelCountThreshold: null
@@ -218,7 +216,6 @@ namespace Test
                 pod,
                 cpuUsage: "100000000n",
                 memoryUsage: "256Ki",
-                modelTimestamp: "2024-01-01",
                 detectionCount: 10,
                 modelConfidenceThreshold: null,
                 modelCountThreshold: null
@@ -239,7 +236,6 @@ namespace Test
                 pod,
                 cpuUsage: "100000000n",
                 memoryUsage: "256Ki",
-                modelTimestamp: "2024-01-01",
                 detectionCount: 10,
                 modelConfidenceThreshold: 0.749,
                 modelCountThreshold: 5
@@ -258,15 +254,15 @@ namespace Test
             var pod = CreateTestPod();
 
             // Test 0.5 -> 50%
-            var orcaHelloPod1 = new OrcaHelloPod(pod, "100n", "256Ki", "", 0, 0.5, 2);
+            var orcaHelloPod1 = new OrcaHelloPod(pod, "100n", "256Ki", 0, 0.5, 2);
             Assert.AreEqual("2 @ 50%", orcaHelloPod1.GetConfidenceThreshold());
 
             // Test 0.95 -> 95%
-            var orcaHelloPod2 = new OrcaHelloPod(pod, "100n", "256Ki", "", 0, 0.95, 10);
+            var orcaHelloPod2 = new OrcaHelloPod(pod, "100n", "256Ki", 0, 0.95, 10);
             Assert.AreEqual("10 @ 95%", orcaHelloPod2.GetConfidenceThreshold());
 
             // Test 0.05 -> 5%
-            var orcaHelloPod3 = new OrcaHelloPod(pod, "100n", "256Ki", "", 0, 0.05, 1);
+            var orcaHelloPod3 = new OrcaHelloPod(pod, "100n", "256Ki", 0, 0.05, 1);
             Assert.AreEqual("1 @ 5%", orcaHelloPod3.GetConfidenceThreshold());
         }
     }


### PR DESCRIPTION
Also remove redundant header link from OrcaHelloPod to OrcaHelloOverview

Fixes #549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the model timestamp from the pod details view and stopped showing it in the page header link.

* **Refactor**
  * Simplified pod representation and fetching so pod timestamps are no longer retrieved or stored, reducing extraneous metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->