### PR TITLE
Display Unknown for dataplicity status when fetch fails

### DIFF
--- a/OrcanodeMonitor/Core/DataplicityFetcher.cs
+++ b/OrcanodeMonitor/Core/DataplicityFetcher.cs
@@ -159,7 +159,7 @@ namespace OrcanodeMonitor.Core
                 string jsonArray = await GetDataplicityDataAsync(string.Empty, logger);
                 if (jsonArray.IsNullOrEmpty())
                 {
-                    // Indeterminate result, so don't update any existing nodes to be status Unknown
+                    // Indeterminate result, so update any existing nodes to be status Unknown
                     // since we can't tell if they are online.
                     var unknownNodes = originalList.Where(n => !string.IsNullOrEmpty(n.DataplicitySerial));
                     foreach (var unknownNode in unknownNodes)
@@ -201,7 +201,6 @@ namespace OrcanodeMonitor.Core
                     }
 
                     Orcanode node = Fetcher.FindOrCreateOrcanodeByDataplicitySerial(context.Orcanodes, serial.ToString(), out OrcanodeOnlineStatus oldStatus);
-                    OrcanodeUpgradeStatus oldAgentUpgradeStatus = node.DataplicityUpgradeStatus;
                     long oldDiskCapacityInGigs = node.DiskCapacityInGigs;
 
                     if (device.TryGetProperty("name", out var name))
@@ -267,10 +266,6 @@ namespace OrcanodeMonitor.Core
                     }
                     if (oldStatus != OrcanodeOnlineStatus.Absent)
                     {
-                        if (oldAgentUpgradeStatus != node.DataplicityUpgradeStatus)
-                        {
-                            AddDataplicityAgentUpgradeStatusChangeEvent(context, node, logger);
-                        }
                         if (oldDiskCapacityInGigs != node.DiskCapacityInGigs)
                         {
                             AddDiskCapacityChangeEvent(context, node, logger);
@@ -348,12 +343,6 @@ namespace OrcanodeMonitor.Core
         {
             string value = node.DataplicityConnectionStatus.ToString();
             Fetcher.AddOrcanodeEvent(context, logger, node, OrcanodeEventTypes.DataplicityConnection, value);
-        }
-
-        private static void AddDataplicityAgentUpgradeStatusChangeEvent(IOrcanodeMonitorContext context, Orcanode node, ILogger logger)
-        {
-            string value = node.DataplicityUpgradeStatus.ToString();
-            Fetcher.AddOrcanodeEvent(context, logger, node, OrcanodeEventTypes.AgentUpgradeStatus, value);
         }
 
         private static void AddDiskCapacityChangeEvent(IOrcanodeMonitorContext context, Orcanode node, ILogger logger)

--- a/OrcanodeMonitor/Core/DataplicityFetcher.cs
+++ b/OrcanodeMonitor/Core/DataplicityFetcher.cs
@@ -154,14 +154,22 @@ namespace OrcanodeMonitor.Core
         {
             try
             {
+                List<Orcanode> originalList = await context.Orcanodes.ToListAsync();
+
                 string jsonArray = await GetDataplicityDataAsync(string.Empty, logger);
                 if (jsonArray.IsNullOrEmpty())
                 {
-                    // Indeterminate result, so don't update anything.
+                    // Indeterminate result, so don't update any existing nodes to be status Unknown
+                    // since we can't tell if they are online.
+                    var unknownNodes = originalList.Where(n => !string.IsNullOrEmpty(n.DataplicitySerial));
+                    foreach (var unknownNode in unknownNodes)
+                    {
+                        unknownNode.DataplicityUpgradeAvailable = null;
+                    }
+                    MonitorState.GetFrom(context).LastUpdatedTimestampUtc = DateTime.UtcNow;
+                    await Fetcher.SaveChangesAsync(context);
                     return;
                 }
-
-                List<Orcanode> originalList = await context.Orcanodes.ToListAsync();
 
                 // Create a list to track what nodes are no longer returned.
                 var unfoundList = originalList.ToList();

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -19,6 +19,7 @@ namespace OrcanodeMonitor.Models
         Silent,
         Unstable,
         Lagged,
+        Unknown, // Used when the status is unknown due to missing information.
     }
     public enum OrcanodeUpgradeStatus
     {
@@ -404,6 +405,11 @@ namespace OrcanodeMonitor.Models
         {
             get
             {
+                if (!string.IsNullOrEmpty(DataplicitySerial) && !DataplicityUpgradeAvailable.HasValue)
+                {
+                    // Status is unknown.
+                    return OrcanodeOnlineStatus.Unknown;
+                }
                 if (!DataplicityOnline.HasValue)
                 {
                     return OrcanodeOnlineStatus.Absent;

--- a/OrcanodeMonitor/Models/OrcanodeEvent.cs
+++ b/OrcanodeMonitor/Models/OrcanodeEvent.cs
@@ -173,7 +173,6 @@ namespace OrcanodeMonitor.Models
         public const string MezmoLogging = "Mezmo logging";
         public const string DataplicityConnection = "dataplicity connection";
         public const string SocketXPConnection = "socketxp connection";
-        public const string AgentUpgradeStatus = "agent upgrade status";
         public const string SDCardSize = "SD card size";
     }
 }

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -22,7 +22,7 @@
             <th>OrcaHello Detections</th>
             <th><a href="https://app.mezmo.com/313dbd82f3/logs/view" target="_blank">Logging</a></th>
             <th><a href="https://www.dataplicity.com/app/" target="_blank" rel="noopener noreferrer">Dataplicity</a></th>
-            <th>Dataplicity Version</th>
+            <!-- <th>Dataplicity Version</th> -->
             <th><a href="https://portal.socketxp.com/#/devices" target="_blank" rel="noopener noreferrer">SocketXP</a></th>
             <!-- <th>SD Card Util.</th> -->
         </tr>
@@ -108,14 +108,26 @@
                     </a>
                 </td>
             }
-            <td style="background-color: @Model.NodeDataplicityBackgroundColor(item)">
-                <a asp-page="/DataplicityNode" asp-route-serial="@item.DataplicitySerial" style="color: @Model.NodeDataplicityTextColor(item)">
+            @if (item.DataplicityConnectionStatus == Models.OrcanodeOnlineStatus.Unknown ||
+                 string.IsNullOrWhiteSpace(item.DataplicitySerial))
+            {
+                <td style="background-color: @Model.NodeDataplicityBackgroundColor(item); color: @Model.NodeDataplicityTextColor(item)">
                     @Html.DisplayFor(modelItem => item.DataplicityConnectionStatus)
-                </a>
-            </td>
-            <td style="background-color: @Model.NodeDataplicityUpgradeColor(item)">
-                @Html.DisplayFor(modelItem => item.AgentVersion)
-            </td>
+                </td>
+            }
+            else
+            {
+                <td style="background-color: @Model.NodeDataplicityBackgroundColor(item)">
+                    <a asp-page="/DataplicityNode" asp-route-serial="@item.DataplicitySerial" style="color: @Model.NodeDataplicityTextColor(item)">
+                        @Html.DisplayFor(modelItem => item.DataplicityConnectionStatus)
+                    </a>
+                </td>
+            }
+            <!--
+               <td style="background-color: @Model.NodeDataplicityUpgradeColor(item)">
+                   @Html.DisplayFor(modelItem => item.AgentVersion)
+               </td>
+            -->
             <td style="background-color: @Model.NodeSocketXPBackgroundColor(item)">
                 @if (!string.IsNullOrWhiteSpace(item.SocketXPDeviceId))
                 {
@@ -225,14 +237,19 @@
             <b>Dataplicity Absent</b>: Dataplicity does not know about the node.
         </li>
         <li>
+            <b>Dataplicity Unknown</b>: Cannot tell whether Dataplicity connection is up or down.
+        </li>
+        <li>
             <b>Dataplicity Offline</b>: Dataplicity connection is down.
         </li>
         <li>
             <b>Dataplicity Online</b>: Dataplicity connection is up.
         </li>
-        <li>
-            <b>Dataplicity Version</b>: Dataplicity agent version.
-        </li>
+        <!--
+           <li>
+               <b>Dataplicity Version</b>: Dataplicity agent version.
+           </li>
+        -->
         <li>
             <b>SocketXP Absent</b>: SocketXP does not know about the node.
         </li>

--- a/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeEvents.cshtml.cs
@@ -159,7 +159,6 @@ namespace OrcanodeMonitor.Pages
             OrcanodeEventTypes.DataplicityConnection => "dataplicityConnection",
             OrcanodeEventTypes.SocketXPConnection => "socketXPConnection",
             OrcanodeEventTypes.MezmoLogging => "mezmoLogging",
-            OrcanodeEventTypes.AgentUpgradeStatus => "agentUpgradeStatus",
             OrcanodeEventTypes.SDCardSize => "sdCardSize",
             _ => string.Empty
         };


### PR DESCRIPTION
Also:
* hide Dataplicity Version column
* Remove Dataplicity AgentUpdate events

Fixes #567 #557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Unknown" status to represent cases where node connectivity cannot be determined.

* **Bug Fixes**
  * Improved handling of indeterminate Dataplicity data; system now properly updates nodes and persists state when data is unavailable.

* **UI Changes**
  * Removed Dataplicity Version column from dashboard.
  * Updated dashboard legend to include new "Unknown" status.
  * Refined connection status display rendering based on data availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->