### PR TITLE
Show orcahello as offline if container running but no stream found

### DIFF
--- a/OrcanodeMonitor/Core/OrcaHelloFetcher.cs
+++ b/OrcanodeMonitor/Core/OrcaHelloFetcher.cs
@@ -731,6 +731,11 @@ namespace OrcanodeMonitor.Core
                                         node.OrcaHelloInferencePodLag = now - clipEndTime;
                                     }
                                 }
+                                else
+                                {
+                                    // Clear any stale lag value.
+                                    node.OrcaHelloInferencePodLag = null;
+                                }
                             }
                         }
                         else

--- a/OrcanodeMonitor/Models/Orcanode.cs
+++ b/OrcanodeMonitor/Models/Orcanode.cs
@@ -476,6 +476,11 @@ namespace OrcanodeMonitor.Models
                 {
                     return OrcanodeOnlineStatus.Lagged;
                 }
+                if (!OrcaHelloInferencePodLag.HasValue)
+                {
+                    // Can't find audio.
+                    return OrcanodeOnlineStatus.Offline;
+                }
                 return OrcanodeOnlineStatus.Online;
             }
         }

--- a/OrcanodeMonitor/Pages/Index.cshtml
+++ b/OrcanodeMonitor/Pages/Index.cshtml
@@ -210,7 +210,7 @@
             <b>OrcaHello Absent</b>: No AI inference container is defined.
         </li>
         <li>
-            <b>OrcaHello Offline</b>: AI inference container is not running.
+            <b>OrcaHello Offline</b>: AI inference container is not running or cannot find audio.
         </li>
         <li>
             <b>OrcaHello Lag</b>: Time behind current audio that the AI inference container is running.

--- a/Test/OrcaHelloTests.cs
+++ b/Test/OrcaHelloTests.cs
@@ -57,6 +57,23 @@ namespace Test
         }
 
         [TestMethod]
+        public void TestStatusWhenOrcaHelloOfflineDueToNoAudio()
+        {
+            // Test that OrcaHello status is Offline when pod is ready but no audio stream is found (lag is null).
+            var node = new Orcanode
+            {
+                OrcaHelloId = "test-id",
+                OrcaHelloInferencePodReady = true,
+                OrcaHelloInferencePodLag = null,
+                OrcasoundSlug = "test-node"
+            };
+
+            // Verify the node's OrcaHello status is Offline.
+            Assert.AreEqual(OrcanodeOnlineStatus.Offline, node.OrcaHelloStatus,
+                "OrcaHello status should be Offline when pod is ready but no audio stream is found");
+        }
+
+        [TestMethod]
         public void TestStatusWhenOrcaHelloLagged()
         {
             // Test that OrcaHello status is Lagged when lag exceeds 5 minutes.


### PR DESCRIPTION
Fixes #579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clears stale inference-pod lag when no new lag or legacy index is found, improving offline/lag classification.

* **Documentation**
  * Clarified "OrcaHello Offline" legend to mean the inference container is stopped or audio cannot be detected.

* **Tests**
  * Added a test verifying nodes with missing lag while the inference pod is ready are classified as Offline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/orcasound/orcanode-monitor/pull/581)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->