### PR TITLE
Add specific category to NodeDetections page

### DIFF
--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -680,7 +680,7 @@ namespace OrcanodeMonitor.Core
                             Timestamp = d.Attributes?.Timestamp ?? default,
                             Source = d.Attributes?.Source ?? string.Empty,
                             Description = d.Attributes?.Description ?? string.Empty,
-                            Category = d.Attributes?.Category ?? string.Empty,
+                            GeneralCategory = d.Attributes?.Category ?? string.Empty,
                             IdempotencyKey = d.Attributes?.IdempotencyKey ?? string.Empty,
                         }).ToList();
 
@@ -757,7 +757,7 @@ namespace OrcanodeMonitor.Core
                             Timestamp = d.Attributes?.Timestamp ?? default,
                             Source = d.Attributes?.Source ?? string.Empty,
                             Description = d.Attributes?.Description ?? string.Empty,
-                            Category = d.Attributes?.Category ?? string.Empty,
+                            GeneralCategory = d.Attributes?.Category ?? string.Empty,
                             IdempotencyKey = d.Attributes?.IdempotencyKey ?? string.Empty,
                         }).ToList();
 

--- a/OrcanodeMonitor/Core/Fetcher.cs
+++ b/OrcanodeMonitor/Core/Fetcher.cs
@@ -678,9 +678,9 @@ namespace OrcanodeMonitor.Core
                             ID = d.Id,
                             NodeID = d.Attributes?.FeedId ?? string.Empty,
                             Timestamp = d.Attributes?.Timestamp ?? default,
-                            Source = d.Attributes?.Source ?? string.Empty,
+                            Source = OrcasiteDetection.GetSource(d.Attributes?.Source ?? string.Empty, d.Attributes?.Description ?? string.Empty),
                             Description = d.Attributes?.Description ?? string.Empty,
-                            GeneralCategory = d.Attributes?.Category ?? string.Empty,
+                            OrcasiteCategory = d.Attributes?.Category ?? string.Empty,
                             IdempotencyKey = d.Attributes?.IdempotencyKey ?? string.Empty,
                         }).ToList();
 
@@ -755,9 +755,9 @@ namespace OrcanodeMonitor.Core
                             ID = d.Id,
                             NodeID = d.Attributes?.FeedId ?? string.Empty,
                             Timestamp = d.Attributes?.Timestamp ?? default,
-                            Source = d.Attributes?.Source ?? string.Empty,
+                            Source = OrcasiteDetection.GetSource(d.Attributes?.Source ?? string.Empty, d.Attributes?.Description ?? string.Empty),
                             Description = d.Attributes?.Description ?? string.Empty,
-                            GeneralCategory = d.Attributes?.Category ?? string.Empty,
+                            OrcasiteCategory = d.Attributes?.Category ?? string.Empty,
                             IdempotencyKey = d.Attributes?.IdempotencyKey ?? string.Empty,
                         }).ToList();
 

--- a/OrcanodeMonitor/Models/OrcasiteDetection.cs
+++ b/OrcanodeMonitor/Models/OrcasiteDetection.cs
@@ -44,7 +44,11 @@ namespace OrcanodeMonitor.Models
         public string ID { get; set; } = string.Empty;
         public string NodeID { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
-        public string Category { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Whale, vessel, or human.
+        /// </summary>
+        public string GeneralCategory { get; set; } = string.Empty;
         public string Source { get; set; } = DetectionSource.Machine;
         public string Description { get; set; } = string.Empty;
         public string IdempotencyKey { get; set; } = string.Empty;
@@ -59,7 +63,7 @@ namespace OrcanodeMonitor.Models
             get
             {
                 // Heuristic since reviewed is not a property.
-                if (Category != "whale")
+                if (GeneralCategory != "whale")
                 {
                     return true;
                 }

--- a/OrcanodeMonitor/Models/OrcasiteDetection.cs
+++ b/OrcanodeMonitor/Models/OrcasiteDetection.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Orcanode Monitor contributors
 // SPDX-License-Identifier: MIT
 
+using System.Runtime.ExceptionServices;
 using System.Text.Json.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace OrcanodeMonitor.Models
 {
@@ -39,17 +39,62 @@ namespace OrcanodeMonitor.Models
         public string? IdempotencyKey { get; set; }
     }
 
+    public enum DetectionGeneralCategoryEnum
+    {
+        Whale,
+        Vessel,
+        Human,
+        Other
+    }
+
+    public enum DetectionSpecificCategoryEnum
+    {
+        Water,
+        Resident,
+        Transient,
+        Humpback,
+        Vessel,
+        Jingle,
+        Human,
+        Unknown
+    }
+
     public class OrcasiteDetection
     {
         public string ID { get; set; } = string.Empty;
         public string NodeID { get; set; } = string.Empty;
         public DateTime Timestamp { get; set; }
 
+        public static DetectionSource GetSource(string source, string comments)
+        {
+            if (source.ToLower() == "human")
+            {
+                return DetectionSource.Human;
+            }
+            else if (comments.StartsWith("AI:"))
+            {
+                return DetectionSource.PodsAI;
+            }
+            else
+            {
+                return DetectionSource.OrcaHello;
+            }
+        }
+
+        public string OrcasiteCategory { get; set; } = string.Empty;
+
         /// <summary>
         /// Whale, vessel, or human.
         /// </summary>
-        public string GeneralCategory { get; set; } = string.Empty;
-        public string Source { get; set; } = DetectionSource.Machine;
+        public DetectionGeneralCategoryEnum GeneralCategory => OrcasiteCategory.ToLower() switch
+        {
+            DetectionCategory.Whale => DetectionGeneralCategoryEnum.Whale,
+            DetectionCategory.Vessel => DetectionGeneralCategoryEnum.Vessel,
+            DetectionCategory.Human => DetectionGeneralCategoryEnum.Human,
+            _ => DetectionGeneralCategoryEnum.Other
+        };
+
+        public DetectionSource Source { get; set; } = DetectionSource.OrcaHello;
         public string Description { get; set; } = string.Empty;
         public string IdempotencyKey { get; set; } = string.Empty;
 
@@ -63,7 +108,7 @@ namespace OrcanodeMonitor.Models
             get
             {
                 // Heuristic since reviewed is not a property.
-                if (GeneralCategory != "whale")
+                if (GeneralCategory != DetectionGeneralCategoryEnum.Whale)
                 {
                     return true;
                 }
@@ -84,13 +129,15 @@ namespace OrcanodeMonitor.Models
         public const string All = "all";
         public const string Whale = "whale";
         public const string Vessel = "vessel";
+        public const string Human = "human";
         public const string Other = "other";
     }
 
-    public static class DetectionSource
+    public enum DetectionSource
     {
-        public const string All = "all";
-        public const string Human = "human";
-        public const string Machine = "machine";
+        All,
+        Human,
+        OrcaHello,
+        PodsAI
     }
 }

--- a/OrcanodeMonitor/Models/OrcasiteDetection.cs
+++ b/OrcanodeMonitor/Models/OrcasiteDetection.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Orcanode Monitor contributors
 // SPDX-License-Identifier: MIT
 
-using System.Runtime.ExceptionServices;
 using System.Text.Json.Serialization;
 
 namespace OrcanodeMonitor.Models
@@ -86,7 +85,7 @@ namespace OrcanodeMonitor.Models
         /// <summary>
         /// Whale, vessel, or human.
         /// </summary>
-        public DetectionGeneralCategoryEnum GeneralCategory => OrcasiteCategory.ToLower() switch
+        public DetectionGeneralCategoryEnum GeneralCategory => OrcasiteCategory.ToLowerInvariant() switch
         {
             DetectionCategory.Whale => DetectionGeneralCategoryEnum.Whale,
             DetectionCategory.Vessel => DetectionGeneralCategoryEnum.Vessel,

--- a/OrcanodeMonitor/Pages/Detections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Detections.cshtml.cs
@@ -249,7 +249,7 @@ namespace OrcanodeMonitor.Pages
                                 if (inPastWeek) weekData.NegativeHumanDetectionCount++;
                             }
                         }
-                        else // detection.Source == "machine"
+                        else // detection.Source == OrcaHello or PodsAI.
                         {
                             // Find the matching InferenceSystemDetection.
                             MachineDetection? inferenceSystemDetection = machineDetections.Where(d => d.Id == detection.IdempotencyKey).FirstOrDefault();

--- a/OrcanodeMonitor/Pages/Detections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Detections.cshtml.cs
@@ -238,7 +238,7 @@ namespace OrcanodeMonitor.Pages
                                 }
                                 continue;
                             }
-                            if (detection.Category == "whale")
+                            if (detection.GeneralCategory == "whale")
                             {
                                 monthData.PositiveHumanDetectionCount++;
                                 if (inPastWeek) weekData.PositiveHumanDetectionCount++;

--- a/OrcanodeMonitor/Pages/Detections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/Detections.cshtml.cs
@@ -227,7 +227,7 @@ namespace OrcanodeMonitor.Pages
                         DetectionData monthData = _detectionCountsPastMonth[node.OrcasoundSlug];
                         DetectionData weekData = _detectionCountsPastWeek[node.OrcasoundSlug];
 
-                        if (detection.Source == "human")
+                        if (detection.Source == DetectionSource.Human)
                         {
                             if (!detection.Reviewed)
                             {
@@ -238,7 +238,7 @@ namespace OrcanodeMonitor.Pages
                                 }
                                 continue;
                             }
-                            if (detection.GeneralCategory == "whale")
+                            if (detection.GeneralCategory == DetectionGeneralCategoryEnum.Whale)
                             {
                                 monthData.PositiveHumanDetectionCount++;
                                 if (inPastWeek) weekData.PositiveHumanDetectionCount++;

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml
@@ -42,7 +42,7 @@
 
     <!-- Filter Buttons for Category -->
     <div>
-        Filter by Category:
+        Filter by Orcasite Category:
         <button id="btn-category-all" class="btn selected" onclick="updateFilter('category', 'all')">All</button>
         <button id="btn-category-whale" class="btn unselected" onclick="updateFilter('category', 'whale')">Whale</button>
         <button id="btn-category-vessel" class="btn unselected" onclick="updateFilter('category', 'vessel')">Vessel</button>
@@ -66,7 +66,7 @@
         <thead>
             <tr>
                 <th>Timestamp (Pacific)</th>
-                <th>Category</th>
+                <th>Orcasite Category</th>
                 <th>Source</th>
                 <th>Status</th>
                 <th align="left">Description</th>
@@ -89,7 +89,7 @@
                         var pacificTime = TimeZoneInfo.ConvertTimeFromUtc(item.Timestamp, pacific);
                     }
                     <td>@pacificTime.ToString("g")</td>
-                    <td>@item.Category</td>
+                    <td>@item.GeneralCategory</td>
                     <td>@item.Source</td>
                     <td>@Model.GetDetectionStatus(item)</td>
                     <td align="left">

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml
@@ -67,6 +67,7 @@
             <tr>
                 <th>Timestamp (Pacific)</th>
                 <th>Orcasite Category</th>
+                <th>PODS-AI Category</th>
                 <th>Source</th>
                 <th>Status</th>
                 <th align="left">Description</th>
@@ -90,6 +91,7 @@
                     }
                     <td>@pacificTime.ToString("g")</td>
                     <td>@item.GeneralCategory</td>
+                    <td>@Model.GetSpecificCategory(item)</td>
                     <td>@item.Source</td>
                     <td>@Model.GetDetectionStatus(item)</td>
                     <td align="left">

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml
@@ -79,7 +79,7 @@
             @if (!Model.RecentDetections.Any())
             {
                 <tr>
-                    <td colspan="7" class="text-center">No detections found for this time period.</td>
+                    <td colspan="8" class="text-center">No detections found for this time period.</td>
                 </tr>
             }
             @foreach (Models.OrcasiteDetection item in Model.RecentDetections)

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
@@ -92,8 +92,15 @@ namespace OrcanodeMonitor.Pages
             {
                 string comments = orcasiteDetection.Description ?? string.Empty;
 
-                // Find the first word after "AI: " in the comments.
-                string firstWord = comments.Split(' ', StringSplitOptions.RemoveEmptyEntries).Skip(1).FirstOrDefault() ?? string.Empty;
+                const string aiPrefix = "AI:";
+                string categoryText = comments.StartsWith(aiPrefix, StringComparison.OrdinalIgnoreCase)
+                                    ? comments[aiPrefix.Length..].TrimStart()
+                                    : comments;
+
+                // Find the first category token after the "AI:" prefix.
+                string firstWord = categoryText
+                                    .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                                    .FirstOrDefault()?.Trim(',', '.', ':', ';') ?? string.Empty;
 
                 // Convert it to the corresponding DetectionSpecificCategoryEnum value.
                 if (Enum.TryParse<DetectionSpecificCategoryEnum>(firstWord, true, out var specificCategory))
@@ -101,7 +108,7 @@ namespace OrcanodeMonitor.Pages
                     return specificCategory;
                 }
 
-                return DetectionSpecificCategoryEnum.Water;
+                return DetectionSpecificCategoryEnum.Unknown;
             }
 
             if (orcasiteDetection.Source == DetectionSource.OrcaHello)

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
@@ -57,7 +57,7 @@ namespace OrcanodeMonitor.Pages
         /// </summary>
         /// <param name="item">Detection</param>
         /// <returns>CSS class</returns>
-        public static string GetCategoryClass(OrcasiteDetection item) => item.Category switch
+        public static string GetCategoryClass(OrcasiteDetection item) => item.GeneralCategory switch
         {
             DetectionCategory.Whale => "whale",
             DetectionCategory.Vessel => "vessel",
@@ -133,7 +133,7 @@ namespace OrcanodeMonitor.Pages
             {
                 return "Unreviewed";
             }
-            else if (orcasiteDetection.Category != "whale")
+            else if (orcasiteDetection.GeneralCategory != "whale")
             {
                 return "Not whale";
             }

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
@@ -35,35 +35,14 @@ namespace OrcanodeMonitor.Pages
         /// </summary>
         /// <param name="item">Detection</param>
         /// <returns>CSS class</returns>
-        public static string GetSourceClass(OrcasiteDetection item)
-        {
-            if (item.Source == DetectionSource.Human)
-            {
-                return "human";
-            }
-            if (item.Source != DetectionSource.Machine)
-            {
-                return string.Empty;
-            }
-            if (item.Description.StartsWith("AI:"))
-            {
-                return "podsai";
-            }
-            return "orcahello";
-        }
+        public static string GetSourceClass(OrcasiteDetection item) => item.Source.ToString().ToLowerInvariant();
 
         /// <summary>
         /// Get category CSS class for a detection.
         /// </summary>
         /// <param name="item">Detection</param>
         /// <returns>CSS class</returns>
-        public static string GetCategoryClass(OrcasiteDetection item) => item.GeneralCategory switch
-        {
-            DetectionCategory.Whale => "whale",
-            DetectionCategory.Vessel => "vessel",
-            DetectionCategory.Other => "other",
-            _ => string.Empty
-        };
+        public static string GetCategoryClass(OrcasiteDetection item) => item.GeneralCategory.ToString().ToLowerInvariant();
 
         /// <summary>
         /// Get time range CSS classes for a detection.
@@ -98,6 +77,50 @@ namespace OrcanodeMonitor.Pages
             return classes;
         }
 
+        public DetectionSpecificCategoryEnum GetSpecificCategory(OrcasiteDetection orcasiteDetection)
+        {
+            if (orcasiteDetection.GeneralCategory == DetectionGeneralCategoryEnum.Vessel)
+            {
+                return DetectionSpecificCategoryEnum.Vessel;
+            }
+            if (orcasiteDetection.GeneralCategory == DetectionGeneralCategoryEnum.Human)
+            {
+                return DetectionSpecificCategoryEnum.Human;
+            }
+
+            if (orcasiteDetection.Source == DetectionSource.PodsAI)
+            {
+                string comments = orcasiteDetection.Description ?? string.Empty;
+
+                // Find the first word after "AI: " in the comments.
+                string firstWord = comments.Split(' ', StringSplitOptions.RemoveEmptyEntries).Skip(1).FirstOrDefault() ?? string.Empty;
+
+                // Convert it to the corresponding DetectionSpecificCategoryEnum value.
+                if (Enum.TryParse<DetectionSpecificCategoryEnum>(firstWord, true, out var specificCategory))
+                {
+                    return specificCategory;
+                }
+
+                return DetectionSpecificCategoryEnum.Water;
+            }
+
+            if (orcasiteDetection.Source == DetectionSource.OrcaHello)
+            {
+                MachineDetection? machineDetection = _machineDetections.FirstOrDefault(d => d.Id == orcasiteDetection.IdempotencyKey);
+                if (machineDetection == null)
+                {
+                    return DetectionSpecificCategoryEnum.Unknown;
+                }
+                if (machineDetection.IsPositive(orcasiteDetection))
+                {
+                    return DetectionSpecificCategoryEnum.Resident;
+                }
+                return DetectionSpecificCategoryEnum.Unknown;
+            }
+
+            return DetectionSpecificCategoryEnum.Unknown;
+        }
+
         /// <summary>
         /// Get the human-readable status of a detection based on its source, review state, and classification.
         /// </summary>
@@ -108,7 +131,8 @@ namespace OrcanodeMonitor.Pages
         /// </returns>
         public string GetDetectionStatus(OrcasiteDetection orcasiteDetection)
         {
-            if (orcasiteDetection.Source == DetectionSource.Machine)
+            if (orcasiteDetection.Source == DetectionSource.OrcaHello ||
+                orcasiteDetection.Source == DetectionSource.PodsAI)
             {
                 MachineDetection? machineDetection = _machineDetections.FirstOrDefault(d => d.Id == orcasiteDetection.IdempotencyKey);
                 if (machineDetection == null)
@@ -133,7 +157,7 @@ namespace OrcanodeMonitor.Pages
             {
                 return "Unreviewed";
             }
-            else if (orcasiteDetection.GeneralCategory != "whale")
+            else if (orcasiteDetection.GeneralCategory != DetectionGeneralCategoryEnum.Whale)
             {
                 return "Not whale";
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection categories are now shown in two separate columns: **“Orcasite Category”** and **“PODS-AI Category”**, with updated filtering label for clearer browsing.

* **Refactor**
  * Detection source and categorization are now derived consistently using enum-based mapping across detections pages.
  * Human vs. whale classification and machine-style status logic now rely on the updated general/specific categories instead of prior string checks.

* **Bug Fixes**
  * Improved PODS-AI specific category extraction: unrecognized values now show as **Unknown**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->