### PR TITLE
Allow filtering node detections by PODS-AI category

### DIFF
--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml
@@ -221,10 +221,10 @@
             // Loop through each row.
             rows.forEach(function(row) {
                 // Check if the row matches the selected time range, category, and source.
-                var matchesTimeRange = (currentFilters.timeRange === 'all' || row.classList.contains(currentFilters.timeRange));
-                var matchesCategory = (currentFilters.category === 'all' || row.classList.contains(currentFilters.category));
-                var matchesLabel = (currentFilters.label === 'all' || row.classList.contains(currentFilters.label));
-                var matchesSource = (currentFilters.source === 'all' || row.classList.contains(currentFilters.source));
+                var matchesTimeRange = (currentFilters.timeRange === 'all' || row.classList.contains("timeRange-" + currentFilters.timeRange));
+                var matchesCategory = (currentFilters.category === 'all' || row.classList.contains("category-" + currentFilters.category));
+                var matchesLabel = (currentFilters.label === 'all' || row.classList.contains("label-" + currentFilters.label));
+                var matchesSource = (currentFilters.source === 'all' || row.classList.contains("source-" + currentFilters.source));
 
                 if (matchesTimeRange) {
                     timeRangeCount++;

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml
@@ -50,6 +50,20 @@
         <p></p>
     </div>
 
+    <!-- Filter Buttons for Label -->
+    <div>
+        Filter by PODS-AI Category:
+        <button id="btn-label-all" class="btn selected" onclick="updateFilter('label', 'all')">All</button>
+        <button id="btn-label-resident" class="btn unselected" onclick="updateFilter('label', 'resident')">Resident</button>
+        <button id="btn-label-transient" class="btn unselected" onclick="updateFilter('label', 'transient')">Transient</button>
+        <button id="btn-label-humpback" class="btn unselected" onclick="updateFilter('label', 'humpback')">Humpback</button>
+        <button id="btn-label-vessel" class="btn unselected" onclick="updateFilter('label', 'vessel')">Vessel</button>
+        <button id="btn-label-human" class="btn unselected" onclick="updateFilter('label', 'human')">Human</button>
+        <button id="btn-label-jingle" class="btn unselected" onclick="updateFilter('label', 'jingle')">Jingle</button>
+        <button id="btn-label-water" class="btn unselected" onclick="updateFilter('label', 'water')">Water</button>
+        <p></p>
+    </div>
+
     <!-- Filter Buttons for Source -->
     <div>
         Filter by Source:
@@ -125,6 +139,7 @@
         var currentFilters = {
             timeRange: 'pastWeek',
             category: 'all',
+            label: 'all',
             source: 'all' };
 
         updateFilter('default', 'default');
@@ -164,6 +179,21 @@
                 newCategoryButton.classList.add('selected');
             }
 
+            // Update label filter.
+            if (filterType == 'label') {
+                var oldLabelButtonId = 'btn-label-' + currentFilters.label;
+                var oldLabelButton = document.getElementById(oldLabelButtonId);
+                oldLabelButton.classList.remove('selected');
+                oldLabelButton.classList.add('unselected');
+
+                currentFilters.label = filterValue;
+
+                var newLabelButtonId = 'btn-label-' + currentFilters.label;
+                var newLabelButton = document.getElementById(newLabelButtonId);
+                newLabelButton.classList.remove('unselected');
+                newLabelButton.classList.add('selected');
+            }
+
             // Update source filter.
             if (filterType == 'source') {
                 var oldSourceButtonId = 'btn-source-' + currentFilters.source;
@@ -193,13 +223,14 @@
                 // Check if the row matches the selected time range, category, and source.
                 var matchesTimeRange = (currentFilters.timeRange === 'all' || row.classList.contains(currentFilters.timeRange));
                 var matchesCategory = (currentFilters.category === 'all' || row.classList.contains(currentFilters.category));
+                var matchesLabel = (currentFilters.label === 'all' || row.classList.contains(currentFilters.label));
                 var matchesSource = (currentFilters.source === 'all' || row.classList.contains(currentFilters.source));
 
                 if (matchesTimeRange) {
                     timeRangeCount++;
                 }
 
-                if (matchesTimeRange && matchesCategory && matchesSource) {
+                if (matchesTimeRange && matchesCategory && matchesLabel && matchesSource) {
                     row.style.display = ''; // Show matching rows.
                     visibleCount++;
                 } else {

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
@@ -80,7 +80,10 @@ namespace OrcanodeMonitor.Pages
         /// <returns>String containing CSS classes</returns>
         public string GetDetectionClasses(OrcasiteDetection item)
         {
-            string classes = GetSourceClass(item) + " " + GetGeneralCategoryClass(item) + " " + GetSpecificCategoryClass(item) + " " + GetTimeRangeClass(item);
+            string classes = "source-" + GetSourceClass(item) + " " +
+                             "category-" + GetGeneralCategoryClass(item) + " " +
+                             "label-" + GetSpecificCategoryClass(item) + " " +
+                             "timeRange-" + GetTimeRangeClass(item);
             return classes;
         }
 

--- a/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
+++ b/OrcanodeMonitor/Pages/NodeDetections.cshtml.cs
@@ -38,11 +38,18 @@ namespace OrcanodeMonitor.Pages
         public static string GetSourceClass(OrcasiteDetection item) => item.Source.ToString().ToLowerInvariant();
 
         /// <summary>
-        /// Get category CSS class for a detection.
+        /// Get general (i.e., Orcasite) category CSS class for a detection.
         /// </summary>
         /// <param name="item">Detection</param>
         /// <returns>CSS class</returns>
-        public static string GetCategoryClass(OrcasiteDetection item) => item.GeneralCategory.ToString().ToLowerInvariant();
+        public static string GetGeneralCategoryClass(OrcasiteDetection item) => item.GeneralCategory.ToString().ToLowerInvariant();
+
+        /// <summary>
+        /// Get specific (i.e., PODS-AI) category CSS class for a detection.
+        /// </summary>
+        /// <param name="item">Detection</param>
+        /// <returns>CSS class</returns>
+        public string GetSpecificCategoryClass(OrcasiteDetection item) => GetSpecificCategory(item).ToString().ToLowerInvariant();
 
         /// <summary>
         /// Get time range CSS classes for a detection.
@@ -73,7 +80,7 @@ namespace OrcanodeMonitor.Pages
         /// <returns>String containing CSS classes</returns>
         public string GetDetectionClasses(OrcasiteDetection item)
         {
-            string classes = GetSourceClass(item) + " " + GetCategoryClass(item) + " " + GetTimeRangeClass(item);
+            string classes = GetSourceClass(item) + " " + GetGeneralCategoryClass(item) + " " + GetSpecificCategoryClass(item) + " " + GetTimeRangeClass(item);
             return classes;
         }
 


### PR DESCRIPTION
Fixes #621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PODS-AI **label** filter to the node detections page.
  * Detection results, counts, and visible rows now react to the selected label (along with the existing time range, Orcasite category, and source filters).

* **Bug Fixes**
  * Improved detection classing so general and specific categories are computed separately and combined reliably with source, label, and time range for accurate filtering and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->